### PR TITLE
[CB-1933] Changed button labels to an array.

### DIFF
--- a/lib/common/plugin/notification.js
+++ b/lib/common/plugin/notification.js
@@ -20,6 +20,7 @@
 */
 
 var exec = require('cordova/exec');
+var platform = require('cordova/platform');
 
 /**
  * Provides access to notifications on the device.
@@ -48,11 +49,31 @@ module.exports = {
      * @param {String} message              Message to print in the body of the alert
      * @param {Function} resultCallback     The callback that is called when user clicks on a button.
      * @param {String} title                Title of the alert dialog (default: Confirm)
-     * @param {String} buttonLabels         Comma separated list of the labels of the buttons (default: 'OK,Cancel')
+     * @param {Array} buttonLabels          Array of the labels of the buttons (default: ['OK', 'Cancel'])
      */
     confirm: function(message, resultCallback, title, buttonLabels) {
         var _title = (title || "Confirm");
-        var _buttonLabels = (buttonLabels || "OK,Cancel");
+        var _buttonLabels = (buttonLabels || ["OK", "Cancel"]);
+
+        // Strings are deprecated!
+        if (typeof _buttonLabels === 'string') {
+            console.log("Notification.confirm(string, function, string, string) is deprecated.  Use Notification.confirm(string, function, string, array).");
+        }
+
+        // Android and iOS take an array of button label names.
+        // Other platforms take a comma separated list.
+        // For compatibility, we convert to the desired type based on the platform.
+        if (platform.id == "android" || platform.id == "ios") {
+            if (typeof _buttonLabels === 'string') {
+                var buttonLabelString = _buttonLabels;
+                _buttonLabels = buttonLabelString.split(",");
+            }
+        } else {
+            if (Array.isArray(_buttonLabels)) {
+                var buttonLabelArray = _buttonLabels;
+                _buttonLabels = buttonLabelArray.toString();
+            }
+        }
         exec(resultCallback, null, "Notification", "confirm", [message, _title, _buttonLabels]);
     },
 

--- a/test/test.notification.js
+++ b/test/test.notification.js
@@ -50,7 +50,7 @@ describe("notification", function () {
 
         it("passes the provided params to the exec method", function () {
             var cb = jasmine.createSpy();
-            notification.confirm("and thats the way it is", cb, "It's like that", "Yes,Yes");
+            notification.confirm("and thats the way it is", cb, "It's like that", ["Yes", "Yes"]);
             expect(exec).toHaveBeenCalledWith(
                 cb, null, "Notification", "confirm",
                 ["and thats the way it is", "It's like that", "Yes,Yes"]);


### PR DESCRIPTION
This allows commas to be included in button label text.
The use of comma-separated strings for this purpose is deprecated.
