### PR TITLE
CB-2595: Prompt mode emits confusing log message

### DIFF
--- a/lib/android/exec.js
+++ b/lib/android/exec.js
@@ -142,7 +142,7 @@ androidExec.nativeToJsModes = nativeToJsModes;
 
 androidExec.setJsToNativeBridgeMode = function(mode) {
     if (mode == jsToNativeModes.JS_OBJECT && !window._cordovaNative) {
-        console.log('Falling back on PROMPT mode since _cordovaNative is missing.');
+        console.log('Falling back on PROMPT mode since _cordovaNative is missing. Expected for Android 3.2 and lower only.');
         mode = jsToNativeModes.PROMPT;
     }
     nativeApiProvider.setPreferPrompt(mode == jsToNativeModes.PROMPT);


### PR DESCRIPTION
When Android switches to PROMPT mode, the log message causes confusion
for users, especially for those having to support Gingerbread. It is tough
though since it can be a legitimate error when restoring state. 
