### PR TITLE
Fixed CB-2620: console.log prints only the first argument on Xcode console

### DIFF
--- a/lib/ios/plugin/ios/console.js
+++ b/lib/ios/plugin/ios/console.js
@@ -34,7 +34,7 @@ function stringify(message) {
                 return "error JSON.stringify()ing argument: " + e;
             }
         } else {
-            return message.toString();
+            return (typeof message === "undefined") ? "undefined" : message.toString();
         }
     } catch (e) {
         return e.toString();
@@ -48,10 +48,20 @@ function stringify(message) {
 function wrappedMethod(console, method) {
     var origMethod = console[method];
 
-    return function(message) {
+    return function() {
+
+        var args = [].slice.call(arguments),
+            len = args.length,
+            i = 0,
+            res = [];
+
+        for ( ; i < len; i++) {
+            res.push(stringify(args[i]));
+        }
+
         exec(null, null,
             'Debug Console', 'log',
-            [ stringify(message), { logLevel: method.toUpperCase() } ]
+            [ res.join(' '), { logLevel: method.toUpperCase() } ]
         );
 
         if (!origMethod) return;


### PR DESCRIPTION
See: https://issues.apache.org/jira/browse/CB-2620

Running:
`console.log('Hello', 'world', {hello: 'world'}, [1,2,3], 1, 2, true, undefined, null);`

On various browsers:

//Output Chrome: 
`Hello world Object {hello: "world"} [1, 2, 3] 1 2 true undefined null`

//Output Firefox:
`Hello world Object { hello= "world" } [ 1 , 2 , 3 ] 1 2 true undefined null`

//Output Safari: 
`Hello world Object [1, 2, 3] 1 2 true undefined null`

However, on Xcode's console, the output before the fix is:
`[LOG] Hello`

After the fix:
`[LOG] Hello world {"hello":"world"} [1,2,3] 1 2 true undefined null`
