### PR TITLE
[CB-2676] Add prompt to Notification API for BlackBerry10

### DIFF
--- a/lib/blackberry/plugin/webworks/notification.js
+++ b/lib/blackberry/plugin/webworks/notification.js
@@ -19,7 +19,8 @@
  *
 */
 
-var cordova = require('cordova');
+var cordova = require('cordova'),
+    platform = require('cordova/platform');
 
 module.exports = {
     alert: function (args, win, fail) {
@@ -47,6 +48,32 @@ module.exports = {
             btnLabels = btnLabel.split(",");
 
         blackberry.ui.dialog.customAskAsync.apply(this, [msg, btnLabels, win, {"title" : title} ]);
+        return { "status" : cordova.callbackStatus.NO_RESULT, "message" : "WebWorks Is On It" };
+    },
+    prompt: function (args, win, fail) {
+        if (args.length !== 3) {
+            return {"status" : 9, "message" : "Notification action - prompt arguments not found"};
+        }
+
+        if (platform.runtime() !== "qnx") {
+            return { "status" : 9, "message" : "Notification action - runtime not supported"};
+        }
+
+        //Unpack and map the args
+        var msg = args[0],
+            title = args[1];
+
+        blackberry.ui.dialog.standardAskAsync.apply(this, [
+            msg,
+            blackberry.ui.dialog.D_PROMPT,
+            function () {
+                win({
+                        buttonIndex: arguments[0].return === "Ok" ? 0 : 1,
+                        input1: arguments[0].promptText
+                    });
+            },
+            {"title" : title} ]);
+
         return { "status" : cordova.callbackStatus.NO_RESULT, "message" : "WebWorks Is On It" };
     }
 };

--- a/test/blackberry/webworks/test.notification.js
+++ b/test/blackberry/webworks/test.notification.js
@@ -21,15 +21,16 @@
 
 describe("notification", function () {
     var notification = require('cordova/plugin/webworks/notification'),
-        cordova = require('cordova');
+        cordova = require('cordova'),
+        platform = require('cordova/platform');
 
     beforeEach(function(){
         global.blackberry = {
             ui:{
                 dialog:{
-                    customAskAsync: jasmine.createSpy()
-                        // apply: jasmine.createSpy('apply')
-                    
+                    customAskAsync: jasmine.createSpy(),
+                    standardAskAsync: jasmine.createSpy(),
+                    D_PROMPT: jasmine.createSpy(),
                 }
             }
         }
@@ -82,6 +83,74 @@ describe("notification", function () {
                 status: cordova.callbackStatus.NO_RESULT,
                 message: "WebWorks Is On It"
             });
+        });
+    });
+
+    describe("prompt", function() {
+
+        var runtime;
+
+        beforeEach(function () {
+            runtime = "qnx";
+            spyOn(platform, "runtime").andCallFake(function () {
+                return runtime;
+            });
+        });
+
+        it("should return that prompt arguments are missing", function () {
+            expect(notification.prompt("")).toEqual({
+                status: 9,
+                message: "Notification action - prompt arguments not found"
+            });
+        });
+
+        it("should return that WebWorks Is On It", function () {
+            expect(notification.prompt(["Message", "Title", []], function () {})).toEqual({
+                status: cordova.callbackStatus.NO_RESULT,
+                message: "WebWorks Is On It"
+            });
+        });
+
+        it("should return that runtime is not supported", function () {
+            runtime = "java";
+            expect(notification.prompt(["Message", "Title", []], function () {})).toEqual({
+                status: 9,
+                message: "Notification action - runtime not supported"
+            });
+        });
+
+        it("should call the blackberry object", function() {
+            notification.prompt(["Message", "Title", []], function () {});
+
+            expect(blackberry.ui.dialog.standardAskAsync).toHaveBeenCalledWith(
+                "Message", 
+                blackberry.ui.dialog.D_PROMPT, 
+                jasmine.any(Function), 
+                { "title" : "Title" });
+        });
+
+        it("should invoke callback with result object for Ok", function() {
+            var win = jasmine.createSpy('win');
+
+            blackberry.ui.dialog.standardAskAsync.andCallFake(function (a, b, callback) {
+                callback({"return": "Ok", promptText: "Hello"});
+            });
+
+            notification.prompt(["Message", "Title", []], win);
+
+            expect(win).toHaveBeenCalledWith({buttonIndex: 0 , input1: "Hello"});
+        });
+
+        it("should invoke callback with result object for Cancel", function() {
+            var win = jasmine.createSpy('win');
+
+            blackberry.ui.dialog.standardAskAsync.andCallFake(function (a, b, callback) {
+                callback({"return": "Cancel"});
+            });
+
+            notification.prompt(["Message", "Title", []], win);
+
+            expect(win).toHaveBeenCalledWith({buttonIndex: 1});
         });
     });
 


### PR DESCRIPTION
This type of dialog does not exist for BBOS or TabletOS. In that case, an error is returned.

On BB10, the prompt dialog does not support button labels, so those are ignored.
