### PR TITLE
[CB-2226] Remove callbacks from FileTransfer.abort() method

### DIFF
--- a/lib/common/plugin/FileTransfer.js
+++ b/lib/common/plugin/FileTransfer.js
@@ -144,12 +144,11 @@ FileTransfer.prototype.download = function(source, target, successCallback, erro
 };
 
 /**
- * Aborts the ongoing file transfer on this object
- * @param successCallback {Function}  Callback to be invoked upon success
- * @param errorCallback {Function}    Callback to be invoked upon error
+ * Aborts the ongoing file transfer on this object. The original error
+ * callback for the file transfer will be called if necessary.
  */
-FileTransfer.prototype.abort = function(successCallback, errorCallback) {
-    exec(successCallback, errorCallback, 'FileTransfer', 'abort', [this._id]);
+FileTransfer.prototype.abort = function() {
+    exec(null, null, 'FileTransfer', 'abort', [this._id]);
 };
 
 module.exports = FileTransfer;


### PR DESCRIPTION
FileTransfer.abort() shouldn't take any callbacks, it should just execute the original error callback.
