### PR TITLE
[CB-2666] Added exec retries for null arguments.

### DIFF
--- a/lib/android/exec.js
+++ b/lib/android/exec.js
@@ -95,7 +95,16 @@ function androidExec(success, fail, service, action, args) {
         window.location = 'http://cdv_exec/' + service + '#' + action + '#' + callbackId + '#' + argsJson;
     } else {
         var messages = nativeApiProvider.get().exec(service, action, callbackId, argsJson);
-        androidExec.processMessages(messages);
+        // If argsJson was received by Java as null, try again with the PROMPT bridge mode.
+        // This happens in rare circumstances, such as when certain Unicode characters are passed over the bridge on a Galaxy S2.  See CB-2666.
+        if (jsToNativeBridgeMode == jsToNativeModes.JS_OBJECT && messages === "@Null arguments.") {
+            androidExec.setJsToNativeBridgeMode(jsToNativeModes.PROMPT);
+            androidExec(success, fail, service, action, args);
+            androidExec.setJsToNativeBridgeMode(jsToNativeModes.JS_OBJECT);
+            return;
+        } else {
+            androidExec.processMessages(messages);
+        }
     }
     if (cordova.callbacks[callbackId]) {
         if (success || fail) {


### PR DESCRIPTION
When Java sends back a message saying that null arguments were received, we try to send them again with a different bridge mode.
