### PR TITLE
[CB-2785] Switch executeScript/injectCSS to call dedicated plugin methods

### DIFF
--- a/lib/common/plugin/InAppBrowser.js
+++ b/lib/common/plugin/InAppBrowser.js
@@ -53,9 +53,9 @@ InAppBrowser.prototype = {
 
     executeScript: function(injectDetails, cb) {
         if (injectDetails.code) {
-            exec(cb, null, "InAppBrowser", "injectScriptCode", [injectDetails.code]);
+            exec(cb, null, "InAppBrowser", "injectScriptCode", [injectDetails.code, !!cb]);
         } else if (injectDetails.file) {
-            exec(cb, null, "InAppBrowser", "injectScriptFile", [injectDetails.file]);
+            exec(cb, null, "InAppBrowser", "injectScriptFile", [injectDetails.file, !!cb]);
         } else {
             throw new Error('executeScript requires exactly one of code or file to be specified');
         }
@@ -63,9 +63,9 @@ InAppBrowser.prototype = {
 
     insertCSS: function(injectDetails, cb) {
         if (injectDetails.code) {
-            exec(cb, null, "InAppBrowser", "injectStyleCode", [injectDetails.code]);
+            exec(cb, null, "InAppBrowser", "injectStyleCode", [injectDetails.code, !!cb]);
         } else if (injectDetails.file) {
-            exec(cb, null, "InAppBrowser", "injectStyleFile", [injectDetails.file]);
+            exec(cb, null, "InAppBrowser", "injectStyleFile", [injectDetails.file, !!cb]);
         } else {
             throw new Error('insertCSS requires exactly one of code or file to be specified');
         }


### PR DESCRIPTION
This supports the CB-2653 and CB-2654 pull requests for iOS and Android, respectively, and makes the plugin JS conform to the new native-side API.
