### PR TITLE
CB-2850: fix typo of warning to warn

### DIFF
--- a/lib/common/plugin/FileReader.js
+++ b/lib/common/plugin/FileReader.js
@@ -86,7 +86,7 @@ function initRead(reader, file) {
 
     if (typeof file == 'string') {
         // Deprecated in Cordova 2.4.
-        console.warning('Using a string argument with FileReader.readAs functions is deprecated.');
+        console.warn('Using a string argument with FileReader.readAs functions is deprecated.');
         reader._fileName = file;
     } else if (typeof file.fullPath == 'string') {
         reader._fileName = file.fullPath;


### PR DESCRIPTION
Fix typo from log.warning to log.warn
