### PR TITLE
Add support for firing 'deviceready' events registered before cordova-js is loaded.

### DIFF
--- a/lib/cordova.js
+++ b/lib/cordova.js
@@ -149,9 +149,8 @@ var cordova = {
                   documentEventHandlers[type].fire(evt);
               }, 0);
             }
-        } else {
-            document.dispatchEvent(evt);
         }
+        document.dispatchEvent(evt);
     },
     fireWindowEvent: function(type, data) {
         var evt = createEvent(type,data);


### PR DESCRIPTION
... is loaded.

Tested on iOS.
