### PR TITLE
[CB-3505] [BlackBerry10] Remove DOMContentLoaded dependency for deviceready

### DIFF
--- a/lib/scripts/bootstrap-blackberry10.js
+++ b/lib/scripts/bootstrap-blackberry10.js
@@ -129,8 +129,6 @@
     });
 }());
 
-document.addEventListener("DOMContentLoaded", function () {
-    document.addEventListener("webworksready", function () {
-        require('cordova/channel').onNativeReady.fire();
-    });
+document.addEventListener("webworksready", function () {
+    require('cordova/channel').onNativeReady.fire();
 });


### PR DESCRIPTION
Necessary for scenarios where cordova.js is injected after DOMContentLoaded
