### PR TITLE
Use grunt's built in jshint. CB-3964

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -147,36 +147,11 @@ module.exports = function(grunt) {
         }, done);
     });
 
-    // TODO - Delete this task and use Grunt's built-in jshint (CB-3964).
-    grunt.registerTask('_hint', 'Runs jshint.', function() {
-        var done = this.async();
-        var knownWarnings = [
-            "Redefinition of 'FileReader'",
-            "Redefinition of 'require'",
-            "Read only",
-            "Redefinition of 'console'"
-        ];
-        var filterKnownWarnings = function(el, index, array) {
-            var wut = true;
-            // filter out the known warnings listed out above
-            knownWarnings.forEach(function(e) {
-                wut = wut && (el.indexOf(e) == -1);
-            });
-            wut = wut && (!el.match(/\d+ errors/));
-            return wut;
-        };
-
-        childProcess.exec("jshint lib", function(err,stdout,stderr) {
-            var exs = stdout.split('\n');
-            grunt.log.writeln(exs.filter(filterKnownWarnings).join('\n'));
-            done();
-        });
-    });
     grunt.loadNpmTasks('grunt-contrib-clean');
     grunt.loadNpmTasks('grunt-contrib-jshint');
 
     // Default task(s).
-    grunt.registerTask('build', ['cordovajs', '_hint', '_complainwhitespace']);
+    grunt.registerTask('build', ['cordovajs', 'jshint', '_complainwhitespace']);
     grunt.registerTask('default', ['build', '_test']);
     grunt.registerTask('test', ['build', '_test']);
     grunt.registerTask('btest', ['build', '_btest']);

--- a/lib/common/urlutil.js
+++ b/lib/common/urlutil.js
@@ -27,6 +27,6 @@ var anchorEl = document.createElement('a');
  * For relative URLs, converts them to absolute ones.
  */
 urlutil.makeAbsolute = function(url) {
-  anchorEl.href = url;
-  return anchorEl.href;
+    anchorEl.href = url;
+    return anchorEl.href;
 };

--- a/lib/scripts/require.js
+++ b/lib/scripts/require.js
@@ -19,6 +19,9 @@
  *
 */
 
+/*jshint -W079 */
+/*jshint -W020 */
+
 var require,
     define;
 

--- a/lib/test/mockxhr.js
+++ b/lib/test/mockxhr.js
@@ -19,6 +19,8 @@
  *
 */
 
+/*jshint -W020 */
+
 var utils = require('cordova/utils');
 var activeXhrs = [];
 var isInstalled = false;


### PR DESCRIPTION
Changing the gruntfile to use the "built in" jshint stuff. 

i added these directives:

```
/*jshint -W079 */
/*jshint -W020 */
```

to the appropriate files to get rid of the redefinition and readonly warnings.

There were some indentation issues with urlutil.js that i had to fix to be lint free
