### PR TITLE
[CB-4942] BlackBerry10 never fires deviceready using cordova 3.1.0-rc1

### DIFF
--- a/lib/blackberry10/platform.js
+++ b/lib/blackberry10/platform.js
@@ -37,17 +37,24 @@ module.exports = {
                 addDocumentEventListener.apply(document, arguments);
                 //Trapping when users add listeners to the webworks ready event
                 //This way we can make sure not to fire the event before there is a listener
-                if (event.toLowerCase() === 'webworksready') {
+                if (type.toLowerCase() === 'webworksready') {
                     listenerRegistered = true;
                     fireWebworksReadyEvent();
                 }
             }
         };
 
+        channel.onDOMContentLoaded.subscribe(function () {
+            document.addEventListener("webworksready", function () {
+                fireWebworksReadyEvent();
+            });
+        });
+
         channel.onPluginsReady.subscribe(function () {
             webworksReady = true;
             fireWebworksReadyEvent();
         });
+
 
         //Only fire the webworks event when both webworks is ready and a listener is registered
         function fireWebworksReadyEvent() {


### PR DESCRIPTION
- Fix typo event.toLowerCase to type.type.toLowerCase
- Add document.addEventListener("webworksready"
