### PR TITLE
CB-5316 Spell Cordova as a brand unless it's a command or script

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Build the .js file and drop it in as a replacement for cordova.js.
     {
       id:"atari",
       initialize:function(){
-        console.log('firing up cordova in my atari, yo.');
+        console.log('firing up Cordova in my Atari, yo.');
       },
       objects:{
         cordova:{

--- a/build/gv-requires.js
+++ b/build/gv-requires.js
@@ -28,7 +28,7 @@ process.chdir(path.join(__dirname, ".."))
 var platforms = getPlatforms()
 
 console.log("//-------------------------------------------------------")
-console.log("// graphviz .dot file for cordova requires by platform")
+console.log("// graphviz .dot file for Cordova requires by platform")
 console.log("// http://www.graphviz.org/")
 console.log("// ")
 console.log("//   - ./build/gv-requires.js > ~/tmp/requires.dot")

--- a/lib/common/builder.js
+++ b/lib/common/builder.js
@@ -85,7 +85,7 @@ function include(parent, objects, clobber, merge) {
                 include(result, obj.children, clobber, merge);
             }
         } catch(e) {
-            utils.alert('Exception building cordova JS globals: ' + e + ' for key "' + key + '"');
+            utils.alert('Exception building Cordova JS globals: ' + e + ' for key "' + key + '"');
         }
     });
 }

--- a/test/test.require.js
+++ b/test/test.require.js
@@ -20,7 +20,7 @@
 */
 
 describe("require + define", function () {
-    it("exist off of cordova", function () {
+    it("exists off of cordova", function () {
         var cordova = require('cordova');
         expect(cordova.require).toBeDefined();
         expect(cordova.define).toBeDefined();


### PR DESCRIPTION
Please note that this is a proposal. If you have comments about the general proposal, please comment in the JIRA issue, thanks.

Yes, Atari and exists aren't really part of spelling Cordova correctly, but they suffered from being _in the neighborhood_
