### PR TITLE
Update exec.js

### DIFF
--- a/src/ios/exec.js
+++ b/src/ios/exec.js
@@ -166,6 +166,9 @@ function iOSExec() {
             return;
         } catch (e) {}
     }
+    
+    // If actionArgs is not provided, default to an empty array
+    actionArgs = actionArgs || [];
 
     // Register the callbacks and add the callbackId to the positional
     // arguments if given.


### PR DESCRIPTION
The spec implies that the last argument of cordova.exec() should be optional.  However, if it is omitted, iOS emits a cryptic NSInvalidArgumentException.  This can be avoided if actionArgs defaults to an empty array.
