### PR TITLE
CB-5438 Exclude local symlinks from jshint

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -38,7 +38,7 @@ module.exports = function(grunt) {
             options: {
                 jshintrc: '.jshintrc',
             },
-            src: [ 'src/**/*.js' ]
+            src: ['src/**/*.js', '!src/test/androidexec.js', '!src/test/iosexec.js']
         },
     });
 


### PR DESCRIPTION
Both /src/test/androidexec.js and /src/test/iosexec.js are symlinks to
/src/android/exec.js and /src/ios/exec.js

Symlinks don't work on the Windows platform and are represented there as
a text file with the contents being a text description of where it
should be pointing at.

The problem is that the jshint task of the build tries to parse those
'text' files as js files, which fails for obvious reasons.

My solution is to explicitly exclude those 2 symlink files from the
jshint task. The files they point at are included in the src/*_/_.js
jshint src setting, so they will get checked anyway.

Now we can successfully run grunt build on Windows.
