### PR TITLE
[fxos] Remove hardcoded cordova version

### DIFF
--- a/src/firefoxos/platform.js
+++ b/src/firefoxos/platform.js
@@ -21,7 +21,6 @@
 
 module.exports = {
     id: 'firefoxos',
-    cordovaVersion: '3.0.0',
 
     bootstrap: function() {
         require('cordova/modulemapper').clobbers('cordova/exec/proxy', 'cordova.commandProxy');


### PR DESCRIPTION
There doesn't seem to be a need to hardcode cordova version. It causes plugins that require a higher versions to fail to install for firefoxos.
