### PR TITLE
CB-6911 - iOS 8 - "deprecated attempt to access property" errors when accessing anything off window.navigator

### DIFF
--- a/src/common/init.js
+++ b/src/common/init.js
@@ -55,6 +55,16 @@ function replaceNavigator(origNavigator) {
         for (var key in origNavigator) {
             if (typeof origNavigator[key] == 'function') {
                 newNavigator[key] = origNavigator[key].bind(origNavigator);
+            } else {
+                (function(k) {
+                        Object.defineProperty(newNavigator, k, {
+                            get: function() {
+                                return origNavigator[k];
+                            },
+                            configurable: true,
+                            enumerable: true
+                        });
+                    })(key);
             }
         }
     }

--- a/src/common/init_b.js
+++ b/src/common/init_b.js
@@ -56,6 +56,16 @@ function replaceNavigator(origNavigator) {
         for (var key in origNavigator) {
             if (typeof origNavigator[key] == 'function') {
                 newNavigator[key] = origNavigator[key].bind(origNavigator);
+            } else {
+                (function(k) {
+                        Object.defineProperty(newNavigator, k, {
+                            get: function() {
+                                return origNavigator[k];
+                            },
+                            configurable: true,
+                            enumerable: true
+                        });
+                    })(key);
             }
         }
     }


### PR DESCRIPTION
Tested on iOS 8 UIWebView. Any attempt to call the bridge will result in:
"Deprecated attempt to access property 'userAgent' on a non-Navigator object." in the console of the Web Inspector.

Object.defineProperty seems to have broad support in mobile browsers:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__defineGetter__#Browser_compatibility

Not sure about IE Mobile, that's why I sent this pull request for discussion since these files are common for all platforms. The (safe) alternative is to add this code for iOS only.
