### PR TITLE
CB-8210 Remove unused onDestroy channel

### DIFF
--- a/src/common/channel.js
+++ b/src/common/channel.js
@@ -35,7 +35,6 @@ var utils = require('cordova/utils'),
  * onDeviceReady*              User event fired to indicate that Cordova is ready
  * onResume                    User event fired to indicate a start/resume lifecycle event
  * onPause                     User event fired to indicate a pause lifecycle event
- * onDestroy*                  Internal event fired when app is being destroyed (User should use window.onunload event, not this one).
  *
  * The events marked with an * are sticky. Once they have fired, they will stay in the fired state.
  * All listeners that subscribe after the event is fired will be executed right away.
@@ -246,9 +245,6 @@ channel.create('onResume');
 
 // Event to indicate a pause lifecycle event
 channel.create('onPause');
-
-// Event to indicate a destroy lifecycle event
-channel.createSticky('onDestroy');
 
 // Channels that must fire before "deviceready" is fired.
 channel.waitForInitialization('onCordovaReady');


### PR DESCRIPTION
- Channel was defined as internal event and fired by javascript eval()
- Rather than change firing of event, simpler to remove as was not used

Related to apache/cordova-android#146