### PR TITLE
CB-7992 prohibit multiple cordova includes

### DIFF
--- a/src/cordova.js
+++ b/src/cordova.js
@@ -19,6 +19,8 @@
  *
 */
 
+if ("cordova" in window) { throw new Error("cordova already defined"); };
+
 
 var channel = require('cordova/channel');
 var platform = require('cordova/platform');

--- a/src/cordova_b.js
+++ b/src/cordova_b.js
@@ -19,6 +19,8 @@
  *
 */
 
+if ("cordova" in window) { throw new Error("cordova already defined"); };
+
 /*global symbolList*/
 
 var channel = require('cordova/channel');


### PR DESCRIPTION
Verify that window.cordova does not already exist and throw error if it does.
Tested on ios/android/wp8.