### PR TITLE
CB-8674: Creates a 'cordova.env' object...

### DIFF
--- a/src/cordova.js
+++ b/src/cordova.js
@@ -98,6 +98,7 @@ var cordova = {
     version:PLATFORM_VERSION_BUILD_LABEL,
     platformVersion:PLATFORM_VERSION_BUILD_LABEL,
     platformId:platform.id,
+    env:{},
     /**
      * Methods to add/remove your own addEventListener hijacking on document + window.
      */

--- a/src/windows/platform.js
+++ b/src/windows/platform.js
@@ -41,9 +41,15 @@ module.exports = {
             var resumingHandler = function resumingHandler() {
                 cordova.fireDocumentEvent('resume',null,true);
             };
+            
+            var activationHandler = function activationHandler(e) {
+                cordova.env = (cordova.env || { });
+                cordova.env.args = e.detail;
+            };
 
             app.addEventListener("checkpoint", checkpointHandler);
             Windows.UI.WebUI.WebUIApplication.addEventListener("resuming", resumingHandler, false);
+            app.addEventListener('activated', activationHandler);
             app.start();
         };
 


### PR DESCRIPTION
Creates a 'cordova.env' object, and then on Windows hangs the activation arguments off of cordova.env.args.  This should allow plugins to capture the activation arguments even though the 'activated' event fires before plugins load on Windows.

Plugin authors have validated that this addresses the need.
https://issues.apache.org/jira/browse/CB-8674