### PR TITLE
CB-9016: Added template-packaged WinJS reference for Windows 10 support.

### DIFF
--- a/src/windows/platform.js
+++ b/src/windows/platform.js
@@ -50,7 +50,10 @@ module.exports = {
         if (!window.WinJS) {
             var scriptElem = document.createElement("script");
 
-            if (navigator.appVersion.indexOf("Windows Phone 8.1;") !== -1) {
+            if (navigator.appVersion.indexOf('MSAppHost/3.0') !== -1) {
+                // Windows 10 UWP
+                scriptElem.src = '/WinJS/js/WinJS.js';
+            } else if (navigator.appVersion.indexOf("Windows Phone 8.1;") !== -1) {
                 // windows phone 8.1 + Mobile IE 11
                 scriptElem.src = "//Microsoft.Phone.WinJS.2.1/js/base.js";
             } else if (navigator.appVersion.indexOf("MSAppHost/2.0;") !== -1) {


### PR DESCRIPTION
Windows 10 no longer has a Framework Reference for WinJS, instead we include it in the project template (since we guarantee that at least WinJS Promises and ALM events will be present).