### PR TITLE
CB-9057: Updated cordova.js for Windows to refer to base.js instead of winjs.js

### DIFF
--- a/src/legacy-exec/windows/platform.js
+++ b/src/legacy-exec/windows/platform.js
@@ -52,7 +52,7 @@ module.exports = {
 
             if (navigator.appVersion.indexOf('MSAppHost/3.0') !== -1) {
                 // Windows 10 UWP
-                scriptElem.src = '/WinJS/js/WinJS.js';
+                scriptElem.src = '/WinJS/js/base.js';
             } else if (navigator.appVersion.indexOf("Windows Phone 8.1;") !== -1) {
                 // windows phone 8.1 + Mobile IE 11
                 scriptElem.src = "//Microsoft.Phone.WinJS.2.1/js/base.js";


### PR DESCRIPTION
Fixed this change for cordova-js as well as in cordova-windows.