### PR TITLE
CB-9129 [webOS] Add webOS platform to cordova-js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -44,6 +44,7 @@ module.exports = function(grunt) {
             "windows": { useWindowsLineEndings: true },
             "wp8": { useWindowsLineEndings: true },
             "firefoxos": {},
+            "webos": {},
             "ubuntu": {},
             "browser": {}
         },

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "cordova-ios": "3.8.x",
     "cordova-blackberry10": "3.7.x" ,
     "cordova-firefoxos": "3.6.x",
+    "cordova-webos": "3.7.x",
     "cordova-ubuntu": "4.0.x",
     "cordova-amazon-fireos": "3.6.x",
     "cordova-wp8": "3.8.x",

--- a/src/legacy-exec/webos/platform.js
+++ b/src/legacy-exec/webos/platform.js
@@ -23,7 +23,7 @@ module.exports = {
     id: 'webos',
     bootstrap: function() {
         var channel = require('cordova/channel');
-        var isLegacy = ((navigator.userAgent.indexOf("webOS")>-1) || (navigator.userAgent.indexOf("hpwOS")>-1));
+        var isLegacy = /(?:web|hpw)OS\/(\d+)/.test(navigator.userAgent);
         var webOSjsLib = (window.webOS!==undefined);
         if(!webOSjsLib && window.PalmSystem && window.PalmSystem.stageReady && isLegacy) {
             window.PalmSystem.stageReady();

--- a/src/legacy-exec/webos/webos/service.js
+++ b/src/legacy-exec/webos/webos/service.js
@@ -19,7 +19,7 @@
  *
 */
 
-var isLegacy = ((navigator.userAgent.indexOf("webOS")>-1) || (navigator.userAgent.indexOf("hpwOS")>-1));
+var isLegacy = /(?:web|hpw)OS\/(\d+)/.test(navigator.userAgent);
 
 function LS2Request(uri, params) {
     this.uri = uri;


### PR DESCRIPTION
Re-adds webOS as a platform option for the cordova-js build system.  Also includes a minor system detection fix in the legacy section that is within https://github.com/apache/cordova-webos/pull/3  Please look over/merge that request prior to this one for smoothness sake. Thanks.