### PR TITLE
CB-9137 Fixes cordova-lib tests failures

### DIFF
--- a/tasks/lib/require-tr.js
+++ b/tasks/lib/require-tr.js
@@ -97,7 +97,7 @@ var requireTr = {
     return false;
   },
   getModules: function(platform) {
-    return this.modules[platform];
+    return this.modules[platform] || [];
   },
   addModule: function(module, platform) {
     if(!module || !module.symbol || !module.path) {


### PR DESCRIPTION
This fixes cordova-lib tests failures in Windows environment. See [CB-9137](https://issues.apache.org/jira/browse/CB-9137).