### PR TITLE
CB-9370 Fixes failing tests on Node 0.12 due to stale dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ git:
   depth: 10
 node_js:
   - "0.10"
+  - "0.12"
 install:
   - cd ..
   - git clone https://github.com/apache/cordova-android --depth 10

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,16 @@
 # appveyor file
 # http://www.appveyor.com/docs/appveyor-yml
+environment:
+  matrix:
+  - nodejs_version: "0.12"
+  - nodejs_version: "0.10"
 
 install:
+  - ps: Install-Product node $env:nodejs_version
+
+  - npm -g install npm
+  - set PATH=%APPDATA%\npm;%PATH%
+
   - cd ..
   - git clone https://github.com/apache/cordova-android --depth 10
   - git clone https://github.com/apache/cordova-ios --depth 10
@@ -13,7 +22,7 @@ install:
   - git clone https://github.com/apache/cordova-amazon-fireos --depth 10
   - git clone https://github.com/apache/cordova-webos --depth 10
   - cd cordova-js
-  - npm install  
+  - npm install --msvs_version=2013
 
 build: off
 

--- a/package.json
+++ b/package.json
@@ -8,9 +8,6 @@
     "type": "git",
     "url": "http://git-wip-us.apache.org/repos/asf/cordova-js.git"
   },
-  "engines": {
-    "node": "~0.10.x"
-  },
   "scripts": {
     "test": "grunt test",
     "build": "grunt compile",
@@ -59,7 +56,7 @@
     },
     {
       "name": "Steve Gill",
-      "email": "stevengill97@gmail.com" 
+      "email": "stevengill97@gmail.com"
     }
   ],
   "devDependencies": {
@@ -69,7 +66,7 @@
     "grunt-contrib-jshint": "0.10.0",
     "istanbul": "^0.3.4",
     "jasmine-node": "1.14.5",
-    "jsdom-nogyp": "0.8.3",
+    "node-jsdom": "~3.x",
     "mkdirp": "^0.5.0",
     "grunt-cli": "0.1.13"
   },

--- a/tasks/lib/test-jsdom.js
+++ b/tasks/lib/test-jsdom.js
@@ -23,12 +23,12 @@ var path             = require('path');
 var fs               = require('fs');
 var collect          = require('./collect');
 var jas              = require('jasmine-node');
-var testLibName      = path.join(__dirname, '..', '..', 'pkg', 'cordova.test.js')
-var testLib          = fs.readFileSync(testLibName, 'utf8')
+var testLibName      = path.join(__dirname, '..', '..', 'pkg', 'cordova.test.js');
+var testLib          = fs.readFileSync(testLibName, 'utf8');
 
-var jsdom    = require("jsdom-nogyp").jsdom;
-var document = jsdom(null, null, { url: 'file:///jsdomtest.info/a?b#c' });
-var window   = document.createWindow();
+var jsdom    = require("node-jsdom").jsdom;
+var document = jsdom(undefined, { url: 'file:///jsdomtest.info/a?b#c' });
+var window   = document.parentWindow;
 
 module.exports = function(callback) {
 


### PR DESCRIPTION
This PR fixes tests on AppVeyor, broken by updated NodeJS on CI machines as described in [CB-9370](https://issues.apache.org/jira/browse/CB-9370). It also adds build matrix that includes node 0.10 and 0.12 for both Travis and AppVeyor.

