### PR TITLE
CB-9505 Correct plugin modules loading within browserify flow

### DIFF
--- a/src/common/init_b.js
+++ b/src/common/init_b.js
@@ -23,9 +23,10 @@ var channel = require('cordova/channel');
 var cordova = require('cordova');
 var modulemapper = require('cordova/modulemapper');
 var platform = require('cordova/platform');
+var pluginloader = require('cordova/pluginloader');
 var utils = require('cordova/utils');
 
-var platformInitChannelsArray = [channel.onDOMContentLoaded, channel.onNativeReady];
+var platformInitChannelsArray = [channel.onDOMContentLoaded, channel.onNativeReady, channel.onPluginsReady];
 
 // setting exec
 cordova.exec = require('cordova/exec');
@@ -109,6 +110,14 @@ if (window._nativeReady) {
 
 // Call the platform-specific initialization.
 platform.bootstrap && platform.bootstrap();
+
+// Wrap in a setTimeout to support the use-case of having plugin JS appended to cordova.js.
+// The delay allows the attached modules to be defined before the plugin loader looks for them.
+setTimeout(function() {
+    pluginloader.load(function() {
+        channel.onPluginsReady.fire();
+    });
+}, 0);
 
 /**
  * Create all cordova objects once native side is ready.

--- a/src/common/pluginloader.js
+++ b/src/common/pluginloader.js
@@ -19,10 +19,6 @@
  *
 */
 
-/*
-    NOTE: this file is NOT used when we use the browserify workflow
-*/
-
 var modulemapper = require('cordova/modulemapper');
 var urlutil = require('cordova/urlutil');
 

--- a/src/common/pluginloader_b.js
+++ b/src/common/pluginloader_b.js
@@ -1,0 +1,63 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var modulemapper = require('cordova/modulemapper');
+
+// Handler for the cordova_plugins.js content.
+// See plugman's plugin_loader.js for the details of this object.
+function handlePluginsObject(moduleList) {
+    // if moduleList is not defined or empty, we've nothing to do
+    if (!moduleList || !moduleList.length) {
+        return;
+    }
+
+    // Loop through all the modules and then through their clobbers and merges.
+    for (var i = 0, module; module = moduleList[i]; i++) {
+        if (module.clobbers && module.clobbers.length) {
+            for (var j = 0; j < module.clobbers.length; j++) {
+                modulemapper.clobbers(module.id, module.clobbers[j]);
+            }
+        }
+
+        if (module.merges && module.merges.length) {
+            for (var k = 0; k < module.merges.length; k++) {
+                modulemapper.merges(module.id, module.merges[k]);
+            }
+        }
+
+        // Finally, if runs is truthy we want to simply require() the module.
+        if (module.runs) {
+            modulemapper.runs(module.id);
+        }
+    }
+}
+
+// Loads all plugins' js-modules. Plugin loading is syncronous in browserified bundle
+// but the method accepts callback to be compatible with non-browserify flow.
+// onDeviceReady is blocked on onPluginsReady. onPluginsReady is fired when there are
+// no plugins to load, or they are all done.
+exports.load = function(callback) {
+    var moduleList = require("cordova/plugin_list");
+    handlePluginsObject(moduleList);
+
+    callback();
+};
+

--- a/tasks/lib/bundle-browserify.js
+++ b/tasks/lib/bundle-browserify.js
@@ -38,9 +38,10 @@ module.exports = function bundle(platform, debug, commitId, platformVersion, pla
     // Replace standart initialization script with browserify's one
     delete modules['cordova/init_b'];
     delete modules['cordova/modulemapper_b'];
-    delete modules['cordova/pluginloader'];
+    delete modules['cordova/pluginloader_b'];
     modules['cordova/init'] = path.resolve(root, 'src', 'common', 'init_b.js');
     modules['cordova/modulemapper'] = path.resolve(root, 'src', 'common', 'modulemapper_b.js');
+    modules['cordova/pluginloader'] = path.resolve(root, 'src', 'common', 'pluginloader_b.js');
 
     // test doesn't support custom paths
     if (platform === 'test') {
@@ -76,6 +77,5 @@ module.exports = function bundle(platform, debug, commitId, platformVersion, pla
 
     return browserify({debug: !!debug, detectGlobals: false})
         .require(modules)
-        .exclude('cordova/plugin_list')
-        .exclude('cordova/pluginloader');
+        .exclude('cordova/plugin_list');
 };


### PR DESCRIPTION
This PR solves problem with a lot of plugins, which uses `js-module` tags with `merges target=""`. Such modules are not loaded correctly, so, for example, plugin proxies on windows platform are not available at runtime.

Instead of injecting `modulemapper` methods and `require` calls into bundle, this PR assumes that bundled plugins modules will be loaded by special 'browserify' version of `cordova/pluginloader` (see below)

This fixes https://issues.apache.org/jira/browse/CB-9505

This PR needs to be merged along with corresponding PR to cordova-lib: https://github.com/apache/cordova-lib/pull/279