### PR TITLE
CB-9370 Switches to another jsdom dependency to avoid package installation issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,10 +67,9 @@
     "grunt-contrib-jshint": "0.10.0",
     "istanbul": "^0.3.4",
     "jasmine-node": "1.14.5",
+    "jsdom-no-contextify": "^3.1.0",
     "mkdirp": "^0.5.0",
-    "node-jsdom": "~3.x",
-    "open": "0.0.5",
-    "through2": "^2.0.0"
+    "open": "0.0.5"
   },
   "dependencies": {
     "browserify": "10.1.3"

--- a/tasks/lib/test-jsdom.js
+++ b/tasks/lib/test-jsdom.js
@@ -26,7 +26,7 @@ var jas              = require('jasmine-node');
 var testLibName      = path.join(__dirname, '..', '..', 'pkg', 'cordova.test.js');
 var testLib          = fs.readFileSync(testLibName, 'utf8');
 
-var jsdom    = require("node-jsdom").jsdom;
+var jsdom    = require("jsdom-no-contextify").jsdom;
 var document = jsdom(undefined, { url: 'file:///jsdomtest.info/a?b#c' });
 var window   = document.parentWindow;
 


### PR DESCRIPTION
This resolves build failures on AppVeyor (https://ci.appveyor.com/project/Humbedooh/cordova-lib/build/1.0.911).
See [CB-9370](https://issues.apache.org/jira/browse/CB-9370) for details.