### PR TITLE
CB-11522 Do not clone the detail object on activation context

### DIFF
--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -108,7 +108,7 @@ utils.clone = function(obj) {
 
     retVal = {};
     for(i in obj){
-        if(!(i in retVal) || retVal[i] != obj[i]) {
+        if((!(i in retVal) || retVal[i] != obj[i]) && typeof obj[i] != 'undefined') {
             retVal[i] = utils.clone(obj[i]);
         }
     }


### PR DESCRIPTION
Fix clone method so that it does not crash trying to clone unavailable property

[Jira issue](https://issues.apache.org/jira/browse/CB-11522)