### PR TITLE
SECURITY ISSUE: Resolve minimatch DDOS issue.

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "open": "0.0.5"
   },
   "dependencies": {
-    "browserify": "10.1.3"
+    "browserify": "13.1.0"
   },
   "cordova-platforms" : {
     "cordova-android"       : "../cordova-android",


### PR DESCRIPTION
`browserify@10.1.3` depends on `glob@4.5.3`; which depends on `minimatch@2.0.10`.

Every installation of the minimatch outputs this to every user machine:

>npm WARN deprecated minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue

And this is still a RegExp DoS issue.