### PR TITLE
CB-12748 - Update CI to test node 4 and 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ sudo: false
 git:
   depth: 10
 node_js:
-  - "0.10"
-  - "0.12"
+  - "4"
+  - "6"
 install:
   - cd ..
   - git clone https://github.com/apache/cordova-android --depth 10

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,8 +2,8 @@
 # http://www.appveyor.com/docs/appveyor-yml
 environment:
   matrix:
-  - nodejs_version: "0.12"
-  - nodejs_version: "0.10"
+  - nodejs_version: "4"
+  - nodejs_version: "6"
 
 install:
   - ps: Install-Product node $env:nodejs_version


### PR DESCRIPTION
### What does this PR do?

Updates AppVeyor and Travis CI tests to use node 4 and 6.

### What testing has been done on this change?

self.

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
