### PR TITLE
CB-13163: fix using relative paths in calls to require.

### DIFF
--- a/src/scripts/require.js
+++ b/src/scripts/require.js
@@ -31,7 +31,7 @@ var require,
         requireStack = [],
     // Map of module ID -> index into requireStack of modules currently being built.
         inProgressModules = {},
-        SEPARATOR = ".";
+        SEPARATOR = "/";
 
 
 

--- a/test/test.require.js
+++ b/test/test.require.js
@@ -145,5 +145,15 @@ describe("require + define", function () {
             define("a", factory);
             require("a");
         });
+
+        it("can handle multiple defined modules that use relative require paths", function () {
+            define("plugin/ios/foo", function (require, exports, module) {
+                module.exports = require("./bar") * 2;
+            });
+            define("plugin/ios/bar", function (require, exports, module) {
+                module.exports = 2;
+            });
+            expect(require("plugin/ios/foo")).toEqual(4);
+        });
     });
 });


### PR DESCRIPTION
Using relative paths in calls to `require` failed.

The single-character patch caused me to chuckle.

Added a test for this as well.