### PR TITLE
CB-8990: bump nodejs requirement to 4.0.0+

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "author": "Gord Tanner <gtanner@gmail.com> (http://github.com/gtanner)",
   "name": "cordova-js",
   "description": "Cordova JavaScript: a unified JavaScript layer for the Cordova suite of projects enabling cross-platform native mobile development of applications using HTML, CSS and JavaScript.",
+  "engines": {
+    "node": ">=4.0.0"
+  },
   "version": "4.2.2-dev",
   "homepage": "http://cordova.apache.org",
   "repository": {


### PR DESCRIPTION
So that we can close https://issues.apache.org/jira/browse/CB-8990