### PR TITLE
4.2.4 patch update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,12 @@ language: node_js
 sudo: false
 git:
   depth: 10
+
 node_js:
   - "4"
   - "6"
   - "8"
+
 install:
   - cd ..
   - git clone https://github.com/apache/cordova-android --depth 10

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -49,17 +49,10 @@ module.exports = function(grunt) {
             "browser": {}
         },
         clean: ['pkg'],
-        jshint: {
-            options: {
-                jshintrc: '.jshintrc',
-            },
-            src: ['src/**/*.js']
-        },
     });
 
     // external tasks
     grunt.loadNpmTasks('grunt-contrib-clean');
-    grunt.loadNpmTasks('grunt-contrib-jshint');
 
     // custom tasks
     grunt.loadTasks('tasks');

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -20,6 +20,9 @@
 -->
 ## Release Notes for Cordova JS ##
 
+### 4.2.4 (Jun 17, 2018)
+* package.json update devDependencies
+
 ### 4.2.3-dev (Oct 30, 2017)
 * [CB-13501](https://issues.apache.org/jira/browse/CB-13501) : added support for node 8
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -20,6 +20,9 @@
 -->
 ## Release Notes for Cordova JS ##
 
+### 4.2.3-dev (Oct 30, 2017)
+* [CB-13501](https://issues.apache.org/jira/browse/CB-13501) : added support for node 8
+
 ### 4.2.2 (Oct 04, 2017)
 * [CB-12017](https://issues.apache.org/jira/browse/CB-12017) updated dependencies for `Browserify`
 * [CB-12762](https://issues.apache.org/jira/browse/CB-12762) point `package.json` repo items to github mirrors instead of apache repos

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ environment:
 install:
   - ps: Install-Product node $env:nodejs_version
 
-  - npm -g install npm
+  - npm -g install npm@5 # QUICK FIX for Node.js 4.x
   - set PATH=%APPDATA%\npm;%PATH%
 
   - cd ..

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "grunt": "^1.0.1",
     "grunt-contrib-clean": "^1.0.0",
     "istanbul": "^0.4.5",
-    "jasmine-node": "1.14.5",
+    "jasmine-node": "github:brodybits/jasmine-node#1.15.0-rc1",
     "jsdom-no-contextify": "^3.1.0",
     "mkdirp": "^0.5.0",
     "open": "0.0.5"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "engines": {
     "node": ">=4.0.0"
   },
-  "version": "4.2.4-dev",
+  "version": "4.2.4",
   "homepage": "http://cordova.apache.org",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "eslint-plugin-standard": "^3.0.1",
     "grunt": "^1.0.1",
     "grunt-contrib-clean": "^1.0.0",
-    "grunt-contrib-jshint": "^1.0.0",
     "istanbul": "^0.4.5",
     "jasmine-node": "1.14.5",
     "jsdom-no-contextify": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "engines": {
     "node": ">=4.0.0"
   },
-  "version": "4.2.3-dev",
+  "version": "4.2.4-dev",
   "homepage": "http://cordova.apache.org",
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

All

### What does this PR do?

Changes proposed for the next patch release:

- Update RELEASENOTES.md for changes from release 4.2.3-dev
- use npm@5 on AppVeyor to resolve issue with CI on Node.js 4
- remove grunt jshint artifacts no longer needed
- Use `github:brodybits/jasmine-node#1.15.0-rc1` in devDependencies to resolve npm audit warning
- Mark version 4.2.4 & update RELEASENOTES.md

If accepted I would like to proceed as follows:
- push the changes proposed here to both `4.2.x` and `master` branches
- mark `4.2.5-dev` in `4.2.x` branch only
- mark `5.0.0-dev` in master branch only
- raise new PR with other changes from #151 (`cb-update-wip1` branch):
  - drop Node.js 4 support from the next major release
  - drop support for old (unsupported) platforms

### What testing has been done on this change?

Raised #151 WIP PR that verifies these changes (along with some other changes desired in the next major release) pass CI testing.

### Checklist

- ~~[Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database~~
- ~~Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.~~
- ~~Added automated test coverage as appropriate for this change.~~