### PR TITLE
cordova-js@4.x cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,12 @@ language: node_js
 sudo: false
 git:
   depth: 10
+
 node_js:
   - "4"
   - "6"
   - "8"
+
 install:
   - cd ..
   - git clone https://github.com/apache/cordova-android --depth 10

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -49,17 +49,10 @@ module.exports = function(grunt) {
             "browser": {}
         },
         clean: ['pkg'],
-        jshint: {
-            options: {
-                jshintrc: '.jshintrc',
-            },
-            src: ['src/**/*.js']
-        },
     });
 
     // external tasks
     grunt.loadNpmTasks('grunt-contrib-clean');
-    grunt.loadNpmTasks('grunt-contrib-jshint');
 
     // custom tasks
     grunt.loadTasks('tasks');

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -20,6 +20,9 @@
 -->
 ## Release Notes for Cordova JS ##
 
+### 4.2.3-dev (Oct 30, 2017)
+* [CB-13501](https://issues.apache.org/jira/browse/CB-13501) : added support for node 8
+
 ### 4.2.2 (Oct 04, 2017)
 * [CB-12017](https://issues.apache.org/jira/browse/CB-12017) updated dependencies for `Browserify`
 * [CB-12762](https://issues.apache.org/jira/browse/CB-12762) point `package.json` repo items to github mirrors instead of apache repos

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ environment:
 install:
   - ps: Install-Product node $env:nodejs_version
 
-  - npm -g install npm
+  - npm -g install npm@5 # QUICK FIX for Node.js 4.x
   - set PATH=%APPDATA%\npm;%PATH%
 
   - cd ..

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "eslint-plugin-standard": "^3.0.1",
     "grunt": "^1.0.1",
     "grunt-contrib-clean": "^1.0.0",
-    "grunt-contrib-jshint": "^1.0.0",
     "istanbul": "^0.4.5",
     "jasmine-node": "1.14.5",
     "jsdom-no-contextify": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "engines": {
     "node": ">=4.0.0"
   },
-  "version": "4.2.3-dev",
+  "version": "4.2.4-dev",
   "homepage": "http://cordova.apache.org",
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

All

### What does this PR do?

*Some* of the changes I had raised in #152 before closing:

- Update RELEASENOTES.md for changes from release 4.2.3-dev
- use npm@5 on AppVeyor to resolve issue with CI on Node.js 4
- remove grunt jshint artifacts no longer needed

Next step is to resolve the npm audit warnings from using jasmine-node. I think the right solution is to switch to jasmine, as was proposed in #140 1.5 years ago.

### What testing has been done on this change?

Already tested as part of #151 WIP PR and closed PR #152.

### Checklist

- ~~[Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database~~
- ~~Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.~~
- ~~Added automated test coverage as appropriate for this change.~~