### PR TITLE
Fix btest by using express (instead of connect, etc.)

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "eslint-plugin-node": "^5.1.1",
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-standard": "^3.0.1",
+    "express": "^4.16.3",
     "grunt": "^1.0.1",
     "grunt-contrib-clean": "^1.0.0",
     "istanbul": "^0.4.5",

--- a/tasks/lib/test-browser.js
+++ b/tasks/lib/test-browser.js
@@ -22,10 +22,10 @@
 
 var fs       = require('fs');
 var path     = require('path');
-var connect  = require('connect');
-var bundle   = require('./bundle');
+
+var express  = require('express');
+
 var collect  = require('./collect');
-var start    = require('open');
 
 var testLibName    = path.join(__dirname, '..', '..', 'pkg', 'cordova.test.js');
 var testLib        = fs.readFileSync(testLibName, 'utf8');
@@ -77,16 +77,16 @@ function routes(app) {
 module.exports = function() {
     console.log('starting browser-based tests');
 
-    var vendor = connect.static(pathToVendor);
-    var jasmine = connect.static(pathToJasmine);
-    var tests  = connect.static(pathToTests);
-    var router = connect.router(routes);
+    var app = express();
 
-    connect(vendor, jasmine, tests, router).listen(3000);
+    app.set('port', 3000);
 
-    console.log("Test Server running on:\n");
-    console.log("http://127.0.0.1:3000\n");
+    app.use(express.static(pathToVendor));
+    app.use(express.static(pathToJasmine));
+    app.use(express.static(pathToTests));
 
-    start('http://127.0.0.1:3000');
+    routes(app);
+
+    app.listen(3000, () => console.log('Test Server running on: http://localhost:3000'));
 };
 


### PR DESCRIPTION
THANKS for GUIDANCE:
https://medium.freecodecamp.org/getting-off-the-ground-with-expressjs-89ada7ef4e59

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

All

### What does this PR do?

Use `express` to fix btest

THANKS for GUIDANCE: <https://medium.freecodecamp.org/getting-off-the-ground-with-expressjs-89ada7ef4e59>

### What testing has been done on this change?

`grunt btest` now starts a local server; opening <http://localhost:3000> in a browser shows passing test suite

This change seems to pass CI as part of WIP PR #151.

### Checklist

- ~~[Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database~~
- ~~Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.~~
- ~~Added automated test coverage as appropriate for this change.~~