### PR TITLE
Lint (almost) all JS files

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 pkg/**
+tasks/vendor

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -16,20 +16,20 @@
  * specific language governing permissions and limitations
  * under the License.
 */
-module.exports = function(grunt) {
+module.exports = function (grunt) {
 
     grunt.initConfig({
         pkg: grunt.file.readJSON('package.json'),
         compile: {
-            "android": {},
-            "ios": {},
-            "osx": {},
-            "test": {},
-            "windows": { useWindowsLineEndings: true },
-            "browser": {},
-            "electron": {}
+            'android': {},
+            'ios': {},
+            'osx': {},
+            'test': {},
+            'windows': { useWindowsLineEndings: true },
+            'browser': {},
+            'electron': {}
         },
-        clean: ['pkg'],
+        clean: ['pkg']
     });
 
     // external tasks

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "https://issues.apache.org/jira/browse/CB"
   },
   "scripts": {
-    "eslint": "eslint src test pkg",
+    "eslint": "eslint .",
     "pretest": "grunt compile:test",
     "test": "npm run eslint && karma start",
     "build": "grunt compile"

--- a/tasks/compile.js
+++ b/tasks/compile.js
@@ -21,48 +21,48 @@ var fs = require('fs');
 var path = require('path');
 var pkgJson = require('../package.json');
 
-module.exports = function(grunt) {
-    grunt.registerMultiTask('compile', 'Packages cordova.js', function() {
+module.exports = function (grunt) {
+    grunt.registerMultiTask('compile', 'Packages cordova.js', function () {
         var done = this.async();
         var platformName = this.target;
         var useWindowsLineEndings = this.data.useWindowsLineEndings;
-       
-        //grabs --platformVersion flag
+
+        // grabs --platformVersion flag
         var flags = grunt.option.flags();
         var platformVersion;
-        var platformPath = undefined;
-        flags.forEach(function(flag) {
-            //see if --platformVersion was passed in
+        var platformPath;
+        flags.forEach(function (flag) {
+            // see if --platformVersion was passed in
             if (flag.indexOf('platformVersion') > -1) {
-                var equalIndex = flag.indexOf('=');
+                let equalIndex = flag.indexOf('=');
                 platformVersion = flag.slice(equalIndex + 1);
             }
-            
-            //see if flags for platforms were passed in
-            //followed by custom paths
+
+            // see if flags for platforms were passed in
+            // followed by custom paths
             if (flag.indexOf(platformName) > -1) {
-                var equalIndex = flag.indexOf('=');
+                let equalIndex = flag.indexOf('=');
                 platformPath = flag.slice(equalIndex + 1);
             }
         });
-        //Use platformPath from package.json, no custom platform path
-        if(platformPath === undefined) { 
-            platformPath = pkgJson['cordova-platforms']['cordova-'+platformName];
+        // Use platformPath from package.json, no custom platform path
+        if (platformPath === undefined) {
+            platformPath = pkgJson['cordova-platforms']['cordova-' + platformName];
         }
-        //Get absolute path to platform
-        if(platformPath) {
+        // Get absolute path to platform
+        if (platformPath) {
             platformPath = path.resolve(platformPath);
         }
-        if(!platformVersion) {
+        if (!platformVersion) {
             var platformPkgJson;
 
-            if(platformPath && fs.existsSync(platformPath)) {
-                platformPkgJson = require(platformPath +'/package.json');
+            if (platformPath && fs.existsSync(platformPath)) {
+                platformPkgJson = require(platformPath + '/package.json');
                 platformVersion = platformPkgJson.version;
             } else {
-                platformVersion="N/A";
+                platformVersion = 'N/A';
             }
         }
         generate(platformName, useWindowsLineEndings, platformVersion, platformPath, done);
     });
-}
+};

--- a/tasks/lib/collect-files.js
+++ b/tasks/lib/collect-files.js
@@ -9,49 +9,45 @@
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to 
+ * Unless required by applicable law or agreed to
  * software distributed under the License is distr
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
  * KIND, either express or implied.  See the Licen
  * specific language governing permissions and lim
  * under the License.
  */
-var fs          = require('fs');
-var path        = require('path');
-var copyProps   = require('./copy-props');
+var fs = require('fs');
+var path = require('path');
+var copyProps = require('./copy-props');
 var getModuleId = require('./get-module-id');
 
+function collectFiles (dir, id) {
+    if (!id) id = '';
 
-function collectFiles(dir, id) {
-    if (!id) id = ''
+    var result = {};
+    var entries = fs.readdirSync(dir);
 
-    var result = {}    
-    var entries = fs.readdirSync(dir)
+    entries = entries.filter(function (entry) {
+        if (entry.match(/\.js$/)) { return true; }
 
-    entries = entries.filter(function(entry) {
-        if (entry.match(/\.js$/)) 
-            return true
-        
-        var stat = fs.statSync(path.join(dir, entry))
+        var stat = fs.statSync(path.join(dir, entry));
 
-        if (stat.isDirectory())  
-            return true
-    })
+        if (stat.isDirectory()) { return true; }
+    });
 
-    entries.forEach(function(entry) {
+    entries.forEach(function (entry) {
         var moduleId = (id ? id + '/' : '') + entry;
-        var fileName = path.join(dir, entry)
-        
-        var stat = fs.statSync(fileName)
+        var fileName = path.join(dir, entry);
+
+        var stat = fs.statSync(fileName);
         if (stat.isDirectory()) {
-            copyProps(result, collectFiles(fileName, moduleId))
+            copyProps(result, collectFiles(fileName, moduleId));
+        } else {
+            moduleId = getModuleId(moduleId);
+            result[moduleId] = fileName;
         }
-        else {
-            moduleId         = getModuleId(moduleId)
-            result[moduleId] = fileName
-        }
-    })
-    return copyProps({}, result)
+    });
+    return copyProps({}, result);
 }
 
 module.exports = collectFiles;

--- a/tasks/lib/compute-commit-id.js
+++ b/tasks/lib/compute-commit-id.js
@@ -17,28 +17,27 @@
  * under the License.
  */
 var childProcess = require('child_process');
-var fs           = require('fs');
-var path         = require('path');
+var fs = require('fs');
+var path = require('path');
 
-
-module.exports = function computeCommitId(callback, cachedGitVersion) {
+module.exports = function computeCommitId (callback, cachedGitVersion) {
 
     if (cachedGitVersion) {
         callback(cachedGitVersion);
         return;
     }
-    
+
     var cordovaJSDir = path.join(__dirname, '../../');
-    
-    //make sure .git directory exists in cordova.js repo
+
+    // make sure .git directory exists in cordova.js repo
     if (fs.existsSync(path.join(__dirname, '../../.git'))) {
         var gitPath = 'git';
         var args = 'rev-list HEAD --max-count=1';
-        childProcess.exec(gitPath + ' ' + args, {cwd:cordovaJSDir}, function(err, stdout, stderr) {
-            var isWindows = process.platform.slice(0, 3) == 'win';
+        childProcess.exec(gitPath + ' ' + args, {cwd: cordovaJSDir}, function (err, stdout, stderr) {
+            var isWindows = process.platform.slice(0, 3) === 'win';
             if (err && isWindows) {
                 gitPath = '"' + path.join(process.env['ProgramFiles'], 'Git', 'bin', 'git.exe') + '"';
-                childProcess.exec(gitPath + ' ' + args, function(err, stdout, stderr) {
+                childProcess.exec(gitPath + ' ' + args, function (err, stdout, stderr) {
                     if (err) {
                         console.warn('Error during git describe: ' + err);
                         done('???');
@@ -54,14 +53,14 @@ module.exports = function computeCommitId(callback, cachedGitVersion) {
             }
         });
     } else {
-        //console.log('no git');
-        //Can't compute commit ID
+        // console.log('no git');
+        // Can't compute commit ID
         done('???');
-    } 
+    }
 
-    function done(stdout) {
+    function done (stdout) {
         var version = stdout.trim();
         cachedGitVersion = version;
         callback(version);
-    };
-}
+    }
+};

--- a/tasks/lib/copy-props.js
+++ b/tasks/lib/copy-props.js
@@ -9,7 +9,7 @@
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to 
+ * Unless required by applicable law or agreed to
  * software distributed under the License is distr
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
  * KIND, either express or implied.  See the Licen
@@ -17,12 +17,12 @@
  * under the License.
  */
 // FIXME should just use underscore or lodash for this
-module.exports = function copyProps(target, source) {
+module.exports = function copyProps (target, source) {
 
     for (var key in source) {
-        if (!source.hasOwnProperty(key)) continue    
-        target[key] = source[key]
+        if (!source.hasOwnProperty(key)) continue;
+        target[key] = source[key];
     }
-    
-    return target
-}
+
+    return target;
+};

--- a/tasks/lib/get-module-id.js
+++ b/tasks/lib/get-module-id.js
@@ -9,7 +9,7 @@
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to 
+ * Unless required by applicable law or agreed to
  * software distributed under the License is distr
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
  * KIND, either express or implied.  See the Licen
@@ -17,6 +17,6 @@
  * under the License.
  */
 
-module.exports = function getModuleId(filename) {
-    return filename.match(/(.*)\.js$/)[1]
-}
+module.exports = function getModuleId (filename) {
+    return filename.match(/(.*)\.js$/)[1];
+};

--- a/tasks/lib/packager.js
+++ b/tasks/lib/packager.js
@@ -16,23 +16,22 @@
  * specific language governing permissions and limitations
  * under the License.
 */
-var fs              = require('fs');
-var path            = require('path');
-var bundle          = require('./bundle');
+var fs = require('fs');
+var path = require('path');
+var bundle = require('./bundle');
 var computeCommitId = require('./compute-commit-id');
 
-
-module.exports = function generate(platform, useWindowsLineEndings, platformVersion, platformPath, callback) {
-    computeCommitId(function(commitId) {
+module.exports = function generate (platform, useWindowsLineEndings, platformVersion, platformPath, callback) {
+    computeCommitId(function (commitId) {
         var outFile;
         var time = new Date().valueOf();
 
         var libraryRelease = bundle(platform, false, commitId, platformVersion, platformPath);
         // if we are using windows line endings, we will also add the BOM
-        if(useWindowsLineEndings) {
-            libraryRelease = "\ufeff" + libraryRelease.split(/\r?\n/).join("\r\n");
+        if (useWindowsLineEndings) {
+            libraryRelease = '\ufeff' + libraryRelease.split(/\r?\n/).join('\r\n');
         }
-        
+
         time = new Date().valueOf() - time;
         if (!fs.existsSync('pkg')) {
             fs.mkdirSync('pkg');
@@ -41,8 +40,7 @@ module.exports = function generate(platform, useWindowsLineEndings, platformVers
         outFile = path.join('pkg', 'cordova.' + platform + '.js');
         fs.writeFileSync(outFile, libraryRelease, 'utf8');
 
-
         console.log('generated cordova.' + platform + '.js @ ' + commitId + ' in ' + time + 'ms');
         callback();
     });
-}
+};

--- a/tasks/lib/strip-header.js
+++ b/tasks/lib/strip-header.js
@@ -9,7 +9,7 @@
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to 
+ * Unless required by applicable law or agreed to
  * software distributed under the License is distr
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
  * KIND, either express or implied.  See the Licen
@@ -17,22 +17,20 @@
  * under the License.
  */
 
-// Strips the license header. 
+// Strips the license header.
 // Basically only the first multi-line comment up to to the closing */
-module.exports = function stripHeader(contents, fileName) {
+module.exports = function stripHeader (contents, fileName) {
     var ls = contents.split(/\r?\n/);
     while (ls[0]) {
         if (ls[0].match(/^\s*\/\*/) || ls[0].match(/^\s*\*/)) {
             ls.shift();
-        }
-        else if (ls[0].match(/^\s*\*\//)) {
+        } else if (ls[0].match(/^\s*\*\//)) {
             ls.shift();
             break;
+        } else {
+            console.log('WARNING: file name ' + fileName + ' is missing the license header');
+            break;
         }
-        else {
-        	console.log("WARNING: file name " + fileName + " is missing the license header");
-        	break;
-    	}
     }
     return ls.join('\n');
-}
+};

--- a/tasks/lib/write-contents.js
+++ b/tasks/lib/write-contents.js
@@ -9,7 +9,7 @@
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to 
+ * Unless required by applicable law or agreed to
  * software distributed under the License is distr
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
  * KIND, either express or implied.  See the Licen
@@ -17,20 +17,19 @@
  * under the License.
  */
 
-module.exports = function writeContents(oFile, fileName, contents, debug) {
-    
+module.exports = function writeContents (oFile, fileName, contents, debug) {
+
     if (debug) {
-        contents += '\n//@ sourceURL=' + fileName
-        contents = 'eval(' + JSON.stringify(contents) + ')'
+        contents += '\n//@ sourceURL=' + fileName;
+        contents = 'eval(' + JSON.stringify(contents) + ')';
         // this bit makes it easier to identify modules
         // with syntax errors in them
-        var handler = 'console.log("exception: in ' + fileName + ': " + e);'
-        handler += 'console.log(e.stack);'
-        contents = 'try {' + contents + '} catch(e) {' + handler + '}'
-    }
-    else {
-        contents = '// file: ' + fileName.split("\\").join("/") + '\n' + contents;
+        var handler = 'console.log("exception: in ' + fileName + ': " + e);';
+        handler += 'console.log(e.stack);';
+        contents = 'try {' + contents + '} catch(e) {' + handler + '}';
+    } else {
+        contents = '// file: ' + fileName.split('\\').join('/') + '\n' + contents;
     }
 
-    oFile.push(contents)
-}
+    oFile.push(contents);
+};

--- a/tasks/lib/write-module.js
+++ b/tasks/lib/write-module.js
@@ -9,31 +9,29 @@
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to 
+ * Unless required by applicable law or agreed to
  * software distributed under the License is distr
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
  * KIND, either express or implied.  See the Licen
  * specific language governing permissions and lim
  * under the License.
  */
-var fs            = require('fs');
-var path          = require('path');
-var stripHeader   = require('./strip-header');
+var fs = require('fs');
+var path = require('path');
+var stripHeader = require('./strip-header');
 var writeContents = require('./write-contents');
 
+module.exports = function writeModule (oFile, fileName, moduleId, debug) {
+    var contents = fs.readFileSync(fileName, 'utf8');
 
-module.exports = function writeModule(oFile, fileName, moduleId, debug) {
-    var contents = fs.readFileSync(fileName, 'utf8')
+    contents = '\n' + stripHeader(contents, fileName) + '\n';
 
-    contents = '\n' + stripHeader(contents, fileName) + '\n'
+    // Windows fix, '\' is an escape, but defining requires '/' -jm
+    moduleId = path.join('cordova', moduleId).split('\\').join('/');
 
-	// Windows fix, '\' is an escape, but defining requires '/' -jm
-    moduleId = path.join('cordova', moduleId).split("\\").join("/");
-    
     var signature = 'function(require, exports, module)';
-    
-    contents = 'define("' + moduleId + '", ' + signature + ' {' + contents + '});\n'
 
-    writeContents(oFile, fileName, contents, debug)    
-}
+    contents = 'define("' + moduleId + '", ' + signature + ' {' + contents + '});\n';
 
+    writeContents(oFile, fileName, contents, debug);
+};

--- a/tasks/lib/write-script.js
+++ b/tasks/lib/write-script.js
@@ -9,7 +9,7 @@
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to 
+ * Unless required by applicable law or agreed to
  * software distributed under the License is distr
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
  * KIND, either express or implied.  See the Licen
@@ -17,12 +17,12 @@
  * under the License.
  */
 
-var fs            = require('fs');
+var fs = require('fs');
 var writeContents = require('./write-contents');
-var stripHeader   = require('./strip-header');
+var stripHeader = require('./strip-header');
 
-module.exports = function writeScript(oFile, fileName, debug) {
+module.exports = function writeScript (oFile, fileName, debug) {
     var contents = fs.readFileSync(fileName, 'utf8');
     contents = stripHeader(contents, fileName);
     writeContents(oFile, fileName, contents, debug);
-}
+};


### PR DESCRIPTION
Prior to this change, files under `tasks/` had not been linted. 3rd party code under `tasks/vendor` is still excluded from linting.