### PR TITLE
Fix adopted CommonJS test `hasOwnProperty`

### DIFF
--- a/src/scripts/require.js
+++ b/src/scripts/require.js
@@ -67,7 +67,7 @@ var define;
     };
 
     define = function (id, factory) {
-        if (modules[id]) {
+        if (Object.prototype.hasOwnProperty.call(modules, id)) {
             throw 'module ' + id + ' already defined';
         }
 

--- a/test/test.require.js
+++ b/test/test.require.js
@@ -231,7 +231,7 @@ describe('require + define', function () {
         });
 
         // Adapted version of CommonJS test `hasOwnProperty`
-        xit('Test#018 : allows properties of Object.prototype as module names', () => {
+        it('Test#018 : allows properties of Object.prototype as module names', () => {
             expect(() => {
                 define('hasOwnProperty', jasmine.createSpy());
             }).not.toThrow();


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
One of the CommonJS tests in #195 exposed a defect in Cordova's module system:

When trying to define a module with a name that also is a property of `Object.prototype`, an exception would occur.

### Description
<!-- Describe your changes in detail -->
Use `Object.prototype.hasOwnProperty.call(modules, id)` to check if a module has already been defined, instead of the previously used `modules[id]`.


### Testing
<!-- Please describe in detail how you tested your changes. -->
The changes make the previously failing test pass.
