### PR TITLE
Fix parsing of some parameter formats in argscheck.checkArgs

### DIFF
--- a/src/common/argscheck.js
+++ b/src/common/argscheck.js
@@ -33,7 +33,7 @@ var typeMap = {
 };
 
 function extractParamName (callee, argIndex) {
-    return (/.*?\((.*?)\)/).exec(callee)[1].split(', ')[argIndex];
+    return (/\(\s*([^)]*?)\s*\)/).exec(callee)[1].split(/\s*,\s*/)[argIndex];
 }
 
 function checkArgs (spec, functionName, args, opt_callee) {

--- a/test/test.argscheck.js
+++ b/test/test.argscheck.js
@@ -78,4 +78,22 @@ describe('argscheck', function () {
         argscheck.enableChecks = false;
         testFunc();
     });
+    it('Test#012 : should be able to extract from all kinds of parameter formats', () => {
+        const check = args => argscheck.checkArgs('ss', 'testFn', args);
+
+        function sparse (
+            a,
+            b
+        ) { check(arguments); }
+        expect(() => sparse(null, '')).toThrowError(/parameter "a"/);
+        expect(() => sparse('', null)).toThrowError(/parameter "b"/);
+
+        // eslint-disable-next-line comma-spacing
+        function dense (a,b) { check(arguments); }
+        expect(() => dense('', null)).toThrowError(/parameter "b"/);
+
+        // eslint-disable-next-line comma-spacing, space-in-parens
+        function funky ( a ,b ) { check(arguments); }
+        expect(() => funky(null, '')).toThrowError(/parameter "a"/);
+    });
 });


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Some parameter formats were not parsed correctly in `argscheck.checkArgs`. This would lead to faulty error messages.


### Description
<!-- Describe your changes in detail -->
Tweaked the RegExes in `extractParamName` to consume all white space around the tokens of interest.

The recognition is still not perfect (e.g. parameters with defaults). For that, one would have to employ an actual parser. But that's a bit over the top here.

### Testing
<!-- Please describe in detail how you tested your changes. -->
Added regression test
