### PR TITLE
argscheck code cleanup

### DIFF
--- a/src/common/argscheck.js
+++ b/src/common/argscheck.js
@@ -68,22 +68,21 @@ function extractParamName (callee, argIndex) {
 function checkArgs (spec, functionName, args, callee) {
     if (!module.exports.enableChecks) return;
 
-    for (let i = 0; i < spec.length; ++i) {
-        const c = spec.charAt(i);
+    [...spec].forEach((c, i) => {
         const cUpper = c.toUpperCase();
         const arg = args[i];
 
         // Pass if any type is allowed
-        if (c === '*') continue;
+        if (c === '*') return;
 
         // Pass if arg is optional and missing
         const isOptional = c === cUpper;
-        if (isOptional && (arg === null || arg === undefined)) continue;
+        if (isOptional && (arg === null || arg === undefined)) return;
 
         // Pass if arg has the required type
         const requiredType = typeMap[cUpper];
         const actualType = utils.typeName(arg);
-        if (actualType === requiredType) continue;
+        if (actualType === requiredType) return;
 
         // arg is invalid, throw error
         const paramName = extractParamName(callee || args.callee, i);
@@ -91,7 +90,7 @@ function checkArgs (spec, functionName, args, callee) {
             `Wrong type for parameter "${paramName}" of ${functionName}: ` +
             `Expected ${requiredType}, but got ${actualType}.`
         );
-    }
+    });
 }
 
 function getValue (value, defaultValue) {

--- a/src/common/argscheck.js
+++ b/src/common/argscheck.js
@@ -87,12 +87,10 @@ function checkArgs (spec, functionName, args, callee) {
 
         // arg is invalid, throw error
         const paramName = extractParamName(callee || args.callee, i);
-        const errMsg = `Wrong type for parameter "${paramName}" of ${functionName}: Expected ${requiredType}, but got ${actualType}.`;
-        // Don't log when running unit tests.
-        if (typeof jasmine === 'undefined') {
-            console.error(errMsg);
-        }
-        throw new TypeError(errMsg);
+        throw new TypeError(
+            `Wrong type for parameter "${paramName}" of ${functionName}: ` +
+            `Expected ${requiredType}, but got ${actualType}.`
+        );
     }
 }
 

--- a/src/common/argscheck.js
+++ b/src/common/argscheck.js
@@ -19,7 +19,7 @@
  *
 */
 
-var utils = require('cordova/utils');
+const utils = require('cordova/utils');
 
 module.exports = { checkArgs, getValue, enableChecks: true };
 
@@ -68,10 +68,10 @@ function extractParamName (callee, argIndex) {
 function checkArgs (spec, functionName, args, callee) {
     if (!module.exports.enableChecks) return;
 
-    for (var i = 0; i < spec.length; ++i) {
-        var c = spec.charAt(i);
-        var cUpper = c.toUpperCase();
-        var arg = args[i];
+    for (let i = 0; i < spec.length; ++i) {
+        const c = spec.charAt(i);
+        const cUpper = c.toUpperCase();
+        const arg = args[i];
 
         // Pass if any type is allowed
         if (c === '*') continue;

--- a/src/common/argscheck.js
+++ b/src/common/argscheck.js
@@ -65,7 +65,7 @@ function extractParamName (callee, argIndex) {
  * Used to extract parameter names for the error message
  * @throws {TypeError} if args do not satisfy spec
  */
-function checkArgs (spec, functionName, args, callee) {
+function checkArgs (spec, functionName, args, callee = args.callee) {
     if (!module.exports.enableChecks) return;
 
     [...spec].forEach((c, i) => {
@@ -85,7 +85,7 @@ function checkArgs (spec, functionName, args, callee) {
         if (actualType === requiredType) return;
 
         // arg is invalid, throw error
-        const paramName = extractParamName(callee || args.callee, i);
+        const paramName = extractParamName(callee, i);
         throw new TypeError(
             `Wrong type for parameter "${paramName}" of ${functionName}: ` +
             `Expected ${requiredType}, but got ${actualType}.`


### PR DESCRIPTION
I did this cleanup to better understand the code for #198. Except for the removed `console.warning`, the code's behavior should remain unchanged by this PR.

IMHO, this could go into a patch release.