### PR TITLE
Add platforms used during tests as devDependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,4 @@ node_js:
   - 12
 
 install:
-  - cd ..
-  - git clone https://github.com/apache/cordova-android --depth 10
-  - git clone https://github.com/apache/cordova-ios --depth 10
-  - git clone https://github.com/apache/cordova-windows --depth 10
-  - git clone https://github.com/apache/cordova-browser --depth 10
-  - cd cordova-js
   - npm install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,13 +8,6 @@ environment:
 
 install:
   - ps: Install-Product node $env:nodejs_version
-
-  - cd ..
-  - git clone https://github.com/apache/cordova-android --depth 10
-  - git clone https://github.com/apache/cordova-ios --depth 10
-  - git clone https://github.com/apache/cordova-windows --depth 10
-  - git clone https://github.com/apache/cordova-browser --depth 10
-  - cd cordova-js
   - npm install
 
 build: off

--- a/package.json
+++ b/package.json
@@ -74,6 +74,8 @@
     "globby": "^9.2.0"
   },
   "devDependencies": {
+    "cordova-android": "^8.0.0",
+    "cordova-ios": "^5.0.0",
     "eslint": "^5.16.0",
     "eslint-config-semistandard": "^13.0.0",
     "eslint-config-standard": "^12.0.0",

--- a/test/build.js
+++ b/test/build.js
@@ -25,11 +25,9 @@ function buildCordovaJsTestBundle (bundlePath) {
 }
 
 function collectTestBuildModules () {
-    const pkgRoot = path.join(__dirname, '..');
-
     // Add platform-specific modules that have tests to the test bundle.
     const platformModules = ['android', 'ios'].map(platform => {
-        const platformPath = path.resolve(pkgRoot, `../cordova-${platform}`);
+        const platformPath = path.dirname(require.resolve(`cordova-${platform}/package`));
         const modulePath = path.join(platformPath, 'cordova-js-src');
         const modules = collectModules(modulePath);
 


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Until now, the tests required the platforms used during tests (`cordova-android` & `cordova-ios`) to be manually checked out to the parent folder of this repository.


### Description
<!-- Describe your changes in detail -->
This PR requires the platforms used during tests as `devDependencies` and changes the test build and CI configurations accordingly.
