### PR TITLE
Make built JS output a bit prettier

### DIFF
--- a/build-tools/bundle.js
+++ b/build-tools/bundle.js
@@ -43,9 +43,9 @@ const bundleTemplate = ({
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at
-\x20
+
      http://www.apache.org/licenses/LICENSE-2.0
-\x20
+
  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -60,4 +60,4 @@ ${modules}
 window.cordova = require('cordova');
 ${includeScript('bootstrap')}
 })();
-`.trim();
+`.trimLeft();

--- a/build-tools/common.js
+++ b/build-tools/common.js
@@ -45,7 +45,9 @@ module.exports = {
 
     // TODO format path relative to pkg.json
     prependFileComment (f) {
-        const comment = `// file: ${f.path}`;
+        const relativePath = path.relative(pkgRoot, f.path);
+        const normalizedPath = path.posix.normalize(relativePath);
+        const comment = `// file: ${normalizedPath}`;
         const contents = [comment, f.contents].join('\n');
         return Object.assign({}, f, { contents });
     },
@@ -53,7 +55,7 @@ module.exports = {
     collectModules (dir) {
         return globby.sync(['**/*.js'], { cwd: dir })
             .map(fileName => ({
-                path: path.relative(pkgRoot, path.join(dir, fileName)),
+                path: path.join(dir, fileName),
                 moduleId: fileName.slice(0, -3)
             }))
             .map(file => ({ [file.moduleId]: file }))

--- a/build-tools/modules.js
+++ b/build-tools/modules.js
@@ -29,12 +29,6 @@ const {
 } = require('./common');
 
 module.exports = function modules (config) {
-    for (const m of values(config.extraModules)) {
-        if (m.path.startsWith('../')) {
-            m.path = path.resolve(m.path);
-        }
-    }
-
     const commonModules = collectCommonModules();
     const modules = values(Object.assign(commonModules, config.extraModules));
     modules.sort((a, b) => a.moduleId.localeCompare(b.moduleId));
@@ -45,7 +39,7 @@ function collectCommonModules () {
     const modules = collectModules(path.join(pkgRoot, 'src/common'));
     modules[''] = {
         moduleId: '',
-        path: path.relative(pkgRoot, path.join(pkgRoot, 'src/cordova.js'))
+        path: path.join(pkgRoot, 'src/cordova.js')
     };
     return modules;
 }

--- a/build-tools/scripts.js
+++ b/build-tools/scripts.js
@@ -47,12 +47,7 @@ function scriptPipeline (config) {
         .then(readContents)
         .then(config.preprocess)
         .then(stripLicenseHeader)
-        .then(prependEmptyLine)
         .then(prependFileComment);
-}
-
-function prependEmptyLine (f) {
-    return Object.assign({}, f, { contents: '\n' + f.contents });
 }
 
 function indexByModuleId (files) {

--- a/test/build.js
+++ b/test/build.js
@@ -37,11 +37,6 @@ function collectTestBuildModules () {
         const moduleId = path.posix.join(platform, 'exec');
         modules[moduleId] = Object.assign({}, modules.exec, { moduleId });
 
-        // Remove plugin/* modules to minimize diff to old build
-        Object.keys(modules)
-            .filter(k => k.startsWith('plugin/'))
-            .forEach(k => delete modules[k]);
-
         return modules;
     });
 


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
In #205 I took great care to preserve the _exact_ format of the built
JS code, so the build refactoring could be verified by diffing the
build output. However, some of the existing formatting is sub-optimal
so this commit optimizes it a little.


### Description
<!-- Describe your changes in detail -->
Most notably, this commit will change file path comments to be relative
paths, not absolute ones. An example for this:

```diff
-// file: /home/raphinesse/code/cordova-android/cordova-js-src/exec.js
+// file: ../cordova-android/cordova-js-src/exec.js
```

### Testing
<!-- Please describe in detail how you tested your changes. -->
I diffed the build artifacts and verified that the diff was as expected. Except for the test build, the diff only consists of whitespace and comments. 
