### PR TITLE
Collect & report test coverage for our browser code

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -48,7 +48,11 @@ module.exports = function (config) {
         // test results reporter to use
         // possible values: 'dots', 'progress'
         // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-        reporters: ['progress'],
+        reporters: ['progress', 'coverage'],
+
+        coverageReporter: {
+            type: 'text'
+        },
 
         // web server port
         port: 9876,

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "jasmine-core": "^3.3.0",
     "karma": "^4.0.1",
     "karma-chrome-launcher": "^2.2.0",
+    "karma-coverage": "^1.1.2",
     "karma-jasmine": "^2.0.1",
     "puppeteer": "^1.14.0"
   }


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
We haven't had code coverage for our client JS tests for some time. With this PR, running the tests also creates a code coverage report.


### Description
<!-- Describe your changes in detail -->
Since our tests are run by `karma`, we use `karma-coverage` to create the code coverage report. However, since we are using a custom module system that is somewhere between RequireJS and CommonJS, we have to do the test code instrumenting ourselves. We use the Istanbul JS API for that. To be as compatible with `karma-coverage` as possible, we do not add `istanbul` to our `devDependencies` but instead, when requiring it, we rely on getting the version of `istanbul` that `karma-coverage` depends on.
