### PR TITLE
Add fallback to nodejs require method in order to use nodejs module

### DIFF
--- a/build-tools/bundle.js
+++ b/build-tools/bundle.js
@@ -53,11 +53,11 @@ const bundleTemplate = ({
  specific language governing permissions and limitations
  under the License.
 */
-;(function() {
+;(function(requireNodejs) {
 var PLATFORM_VERSION_BUILD_LABEL = '${platformVersion}';
 ${includeScript('require')}
 ${modules}
 window.cordova = require('cordova');
 ${includeScript('bootstrap')}
-})();
+})(typeof require === 'function' ? require : null);
 `.trimLeft();

--- a/src/scripts/require.js
+++ b/src/scripts/require.js
@@ -22,7 +22,7 @@
 var require;
 var define;
 
-(function () {
+(function (requireNodejs) {
     var modules = {};
     // Stack of moduleIds currently being built.
     var requireStack = [];
@@ -48,7 +48,11 @@ var define;
 
     require = function (id) {
         if (!modules[id]) {
-            throw 'module ' + id + ' not found';
+            if (requireNodejs) {
+                return requireNodejs(id);
+            } else {
+                throw 'module ' + id + ' not found';
+            }
         } else if (id in inProgressModules) {
             var cycle = requireStack.slice(inProgressModules[id]).join('->') + '->' + id;
             throw 'Cycle in require graph: ' + cycle;
@@ -82,7 +86,8 @@ var define;
     };
 
     define.moduleMap = modules;
-})();
+// eslint-disable-next-line no-undef
+})(requireNodejs);
 
 // Export for use in node
 if (typeof module === 'object' && typeof require === 'function') {


### PR DESCRIPTION
Add fallback to nodejs require method in order to use nodejs module in electron plugin

Platforms affected
Electron

Motivation and Context
Allow using nodejs 'require' method to load nodejs module inside electron platform plugin

Description
Add fallback to nodejs require method in order to use nodejs module in electron plugin

Testing
Create an electron plugin that require nodejs module inside, add it to a sample cordova project and check that plugin works and uses nodejs module. 

sample project should use the following electron config
```
{
    "browserWindow": {
        "webPreferences": {
            "nodeIntegration": false
        }
    }
}
```

