### PR TITLE
Run client-side JS through Babel if desired

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -25,12 +25,28 @@ module.exports = function (grunt) {
     grunt.initConfig({
         pkg: grunt.file.readJSON('package.json'),
         compile: {
-            'android': {},
-            'ios': {},
-            'osx': {},
-            'windows': { useWindowsLineEndings: true },
-            'browser': {},
-            'electron': {}
+            android: {
+                targets: 'Android >= 4.4, ChromeAndroid >= 30'
+            },
+            ios: {
+                targets: 'iOS >= 9'
+            },
+            osx: {
+                // TODO: add actual targets based on platform support
+                // {} means transform any ES2015+ code to ES5
+                targets: {}
+            },
+            windows: {
+                targets: 'Explorer >= 11',
+                useWindowsLineEndings: true
+            },
+            browser: {
+                // {} means transform any ES2015+ code to ES5
+                targets: {}
+            },
+            electron: {
+                targets: 'Electron >= 4'
+            }
         },
         clean: ['pkg']
     });
@@ -45,6 +61,7 @@ module.exports = function (grunt) {
 
         build({
             platformName: this.target,
+            babel: { targets: this.data.targets },
             platformVersion: grunt.option('platformVersion') ||
                              require(platformPkgPath).version,
             extraModules: collectModules(platformModulesPath)

--- a/package.json
+++ b/package.json
@@ -69,6 +69,8 @@
     }
   ],
   "dependencies": {
+    "@babel/core": "^7.6.4",
+    "@babel/preset-env": "^7.6.3",
     "execa": "^1.0.0",
     "fs-extra": "^8.0.1",
     "globby": "^9.2.0"

--- a/test/build.js
+++ b/test/build.js
@@ -25,6 +25,8 @@ function buildCordovaJsTestBundle (bundlePath) {
         platformName: 'test',
         platformVersion: 'N/A',
         extraModules: collectTestBuildModules(),
+        // {} means transform any ES2015+ code to ES5
+        babel: { targets: {} },
         preprocess (f) {
             // Do not instrument our test dummies
             if (f.path.includes('src/legacy-exec/test/')) return f;


### PR DESCRIPTION
### Platforms affected
The ones we want to be affected


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #206


### Description
<!-- Describe your changes in detail -->
This allows to set babel targets for each platform, so that the latest and greatest JavaScript we write will be compiled to whatever is compatible with the platform we're building for.

### Testing
<!-- Please describe in detail how you tested your changes. -->
The babel transform is also applied to the `cordova-js` build for our automated tests (which also include code from the Android and iOS platforms). The tests still pass after that.