### PR TITLE
Re-enable ESLint rules

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -5,4 +5,3 @@ rules:
     - error
     - 4
   camelcase: off
-  padded-blocks: off

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -6,4 +6,3 @@ rules:
     - 4
   camelcase: off
   padded-blocks: off
-  operator-linebreak: off

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -7,4 +7,3 @@ rules:
   camelcase: off
   padded-blocks: off
   operator-linebreak: off
-  no-throw-literal: off

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -21,7 +21,6 @@ const path = require('path');
 const { build, collectModules } = require('./build-tools');
 
 module.exports = function (grunt) {
-
     grunt.initConfig({
         pkg: grunt.file.readJSON('package.json'),
         compile: {

--- a/src/common/init.js
+++ b/src/common/init.js
@@ -137,5 +137,4 @@ channel.join(function () {
     channel.join(function () {
         require('cordova').fireDocumentEvent('deviceready');
     }, channel.deviceReadyChannelsArray);
-
 }, platformInitChannelsArray);

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -162,7 +162,6 @@ utils.extend = (function () {
     var F = function () {};
     // extend Child from Parent
     return function (Child, Parent) {
-
         F.prototype = Parent.prototype;
         Child.prototype = new F();
         Child.__super__ = Parent.prototype;

--- a/src/scripts/require.js
+++ b/src/scripts/require.js
@@ -48,10 +48,10 @@ var define;
 
     require = function (id) {
         if (!modules[id]) {
-            throw 'module ' + id + ' not found';
+            throw new Error('module ' + id + ' not found');
         } else if (id in inProgressModules) {
             var cycle = requireStack.slice(inProgressModules[id]).join('->') + '->' + id;
-            throw 'Cycle in require graph: ' + cycle;
+            throw new Error('Cycle in require graph: ' + cycle);
         }
         if (modules[id].factory) {
             try {
@@ -68,7 +68,7 @@ var define;
 
     define = function (id, factory) {
         if (Object.prototype.hasOwnProperty.call(modules, id)) {
-            throw 'module ' + id + ' already defined';
+            throw new Error('module ' + id + ' already defined');
         }
 
         modules[id] = {

--- a/test/test.builder.js
+++ b/test/test.builder.js
@@ -20,11 +20,9 @@
 */
 
 describe('builder', function () {
-
     var builder = cordova.require('cordova/builder');
 
     it('Test#001 : includes the module into the target', function () {
-
         var target = {};
         var objects = {
             foo: {
@@ -47,7 +45,6 @@ describe('builder', function () {
     });
 
     it('Test#003 : builds out the children', function () {
-
         var target = {};
         var objects = {
             homer: {

--- a/test/test.require.js
+++ b/test/test.require.js
@@ -61,7 +61,7 @@ describe('require + define', function () {
             define('cordova', function () {});
             expect(function () {
                 define('cordova', function () {});
-            }).toThrow('module cordova already defined');
+            }).toThrowError('module cordova already defined');
         });
 
         it("Test#004 : doesn't call the factory method when defining", function () {
@@ -75,7 +75,7 @@ describe('require + define', function () {
         it("Test#005 : throws an exception when module doesn't exist", function () {
             expect(function () {
                 require('your mom');
-            }).toThrow('module your mom not found');
+            }).toThrowError('module your mom not found');
         });
 
         it('Test#006 : throws an exception when modules depend on each other', function () {
@@ -88,7 +88,7 @@ describe('require + define', function () {
 
             expect(function () {
                 require('ModuleA');
-            }).toThrow('Cycle in require graph: ModuleA->ModuleB->ModuleA');
+            }).toThrowError('Cycle in require graph: ModuleA->ModuleB->ModuleA');
         });
 
         it('Test#007 : throws an exception when a cycle of requires occurs', function () {
@@ -104,7 +104,7 @@ describe('require + define', function () {
 
             expect(function () {
                 require('ModuleA');
-            }).toThrow('Cycle in require graph: ModuleA->ModuleB->ModuleC->ModuleA');
+            }).toThrowError('Cycle in require graph: ModuleA->ModuleB->ModuleC->ModuleA');
         });
 
         it('Test#008 : calls the factory method when requiring', function () {
@@ -160,7 +160,7 @@ describe('require + define', function () {
             define('submodule.a', function (require, exports, module) {
                 expect(() => {
                     require('a');
-                }).toThrow('module a not found');
+                }).toThrowError('module a not found');
             });
 
             require('submodule.a');

--- a/test/test.urlutil.js
+++ b/test/test.urlutil.js
@@ -66,5 +66,4 @@ describe('urlutil', function () {
         var rootUrl = window.location.href.replace(/:.*/, '');
         expect(urlutil.makeAbsolute('//www.foo.com/baz%20?foo#bar')).toBe(rootUrl + '://www.foo.com/baz%20?foo#bar');
     });
-
 });

--- a/test/test.utils.js
+++ b/test/test.utils.js
@@ -117,7 +117,6 @@ describe('utils', function () {
         });
 
         it('Test#020 : can clone an object', function () {
-
             var orig = {
                 a: {
                     b: {
@@ -173,5 +172,4 @@ describe('utils', function () {
         expect(uuid).toMatch(/^(\{{0,1}([0-9a-fA-F]){8}-([0-9a-fA-F]){4}-([0-9a-fA-F]){4}-([0-9a-fA-F]){4}-([0-9a-fA-F]){12}\}{0,1})$/);
         expect(uuid).not.toEqual(utils.createUUID());
     });
-
 });


### PR DESCRIPTION
- Reduce exceptions from our ESLint base rule set.
- Do not throw literals

Conservatively, this should go into a major release because the type of thrown object changes for `require`/`define`.