### PR TITLE
fix: move eslint-plugin-es5 to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     }
   ],
   "dependencies": {
-    "eslint-plugin-es5": "^1.4.1",
     "execa": "^1.0.0",
     "fs-extra": "^8.0.1",
     "globby": "^9.2.0"
@@ -80,6 +79,7 @@
     "eslint": "^5.16.0",
     "eslint-config-semistandard": "^13.0.0",
     "eslint-config-standard": "^12.0.0",
+    "eslint-plugin-es5": "^1.4.1",
     "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-node": "^8.0.1",
     "eslint-plugin-promise": "^4.1.1",


### PR DESCRIPTION
As it had erroneously been added to `dependencies` instead.