### PR TITLE
breaking: bump minimum node support >=10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ git:
   depth: 10
 
 node_js:
-  - 8
   - 10
   - 12
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,6 @@
 # http://www.appveyor.com/docs/appveyor-yml
 environment:
   matrix:
-  - nodejs_version: 8
   - nodejs_version: 10
   - nodejs_version: 12
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "cordova-js",
   "description": "Cordova JavaScript: a unified JavaScript layer for the Cordova suite of projects enabling cross-platform native mobile development of applications using HTML, CSS and JavaScript.",
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "version": "6.0.0-dev",
   "homepage": "http://cordova.apache.org",


### PR DESCRIPTION
### Motivation and Context

- Drop unsupported Node.js versions

### Description

- Bump minimum supported Node.js to >=10
- Remove Node.js 8 from CI test workflow

### Testing

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
