### PR TITLE
chore(npm): package cleanup

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+.*
+appveyor.yml
+pkg
+test

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "author": "Gord Tanner <gtanner@gmail.com> (http://github.com/gtanner)",
+  "author": "Apache Software Foundation",
   "name": "cordova-js",
   "description": "Cordova JavaScript: a unified JavaScript layer for the Cordova suite of projects enabling cross-platform native mobile development of applications using HTML, CSS and JavaScript.",
   "engines": {
@@ -7,13 +7,8 @@
   },
   "version": "6.0.0-dev",
   "homepage": "http://cordova.apache.org",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/apache/cordova-js"
-  },
-  "bugs": {
-    "url": "https://issues.apache.org/jira/browse/CB"
-  },
+  "repository": "github:apache/cordova-js",
+  "bugs": "https://github.com/apache/cordova-js/issues",
   "scripts": {
     "lint": "eslint --ignore-path .gitignore .",
     "pretest": "npm run build:test",
@@ -66,6 +61,10 @@
     {
       "name": "Steve Gill",
       "email": "stevengill97@gmail.com"
+    },
+    {
+      "name": "Gord Tanner",
+      "email": "gtanner@gmail.com"
     }
   ],
   "dependencies": {


### PR DESCRIPTION
### Motivation and Context

- Cleanup cordova-js package

### Description

- Updated Package Properties:
  - `author`: change to `Apache Software Foundation`
  - `repository`: use shorten format
  - `bugs`: use GitHub URL and shorten format
  - `contributors`: move previous author information to contributors list
- Added `.npmignore` file to shrink bundled package.

### Testing

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
