### PR TITLE
build: improve cordova-js version ID in built file

### DIFF
--- a/build-tools/bundle.js
+++ b/build-tools/bundle.js
@@ -27,14 +27,14 @@ module.exports = function bundle (scripts, modules, config) {
 };
 
 const bundleTemplate = ({
-    commitId,
+    buildId,
     platformName,
     platformVersion,
     includeScript,
     modules
 }) => `
 // Platform: ${platformName}
-// ${commitId}
+// cordova-js ${buildId}
 /*
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently the SHA of the commit pointed to by `HEAD` is included in the built `cordova.js` file to identify the version of `cordova-js` used to build it. If platforms depend on `cordova-js` in the future (see #169 & #229), they will most likely depend on published packages. Consequently there will be no `cordova-js` repo to get aforementioned information from.

To make things worse, git will automatically use a repo in any parent dir. So if you have `cordova-android/` containing `.git/` and `node_modules/cordova-js/`, the old implementation would use the HEAD of `cordova-android/.git/` to describe `cordova-js`.

Thus, we now include the version from `package.json` instead in that case.

### Description
<!-- Describe your changes in detail -->
- uses `git describe` instead of `git rev-parse HEAD` if in a `cordova-js` repo
- fall back to version from package.json if not in a `cordova-js` repo
- rename and factor out `build-id`


### Testing
<!-- Please describe in detail how you tested your changes. -->
Manually tested both cases.
