### PR TITLE
ci: add node-14.x to workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [10.x, 12.x, 14.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:


### PR DESCRIPTION
### Motivation, Context & Description

* Test with Node 14.x
* Added Node 14.x CI all workflow configurations.

See https://github.com/apache/cordova/issues/223 for more details.


### Testing

* No local testing required.
* Use CI service test results

### Checklist

- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
