### PR TITLE
chore: update .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,6 @@
 .*
-appveyor.yml
+*.tgz
 coverage
 pkg
 test
+karma.conf.js


### PR DESCRIPTION
Excludes `karma.conf.js`, and any previously generated `*.tgz` files from the package generated by `npm pack`. Also removes the outdated `appveyor.yml` from the list of ignores.