### PR TITLE
chore(npm): bump dev dependency cordova-android@9.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -289,6 +289,17 @@
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "dev": true
     },
+    "@netflix/nerror": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@netflix/nerror/-/nerror-1.1.3.tgz",
+      "integrity": "sha512-b+MGNyP9/LXkapreJzNUzcvuzZslj/RGgdVVJ16P2wSlYatfLycPObImqVJSmNAdyeShvNeM/pl3sVZsObFueg==",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "extsprintf": "^1.4.0",
+        "lodash": "^4.17.15"
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -304,9 +315,9 @@
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="
     },
     "@nodelib/fs.walk": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.7.tgz",
-      "integrity": "sha512-BTIhocbPBSrRmHxOAJFtR18oLhxTtAFDAvL8hY1S3iU8k+E60W/YFs4jrixGzQjMpF4qPXxIQHcjVD9dz1C2QA==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
       "requires": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -325,15 +336,15 @@
       "dev": true
     },
     "@types/cors": {
-      "version": "2.8.11",
-      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.11.tgz",
-      "integrity": "sha512-64aQQZXPSo1fdLEE/utClOFVUqDUjyh5j3JorcCTlYQm4r5wsfggx6yhSY6hNudJLkbmIt+pO6xWyCnM0EQgPw==",
+      "version": "2.8.12",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
+      "integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==",
       "dev": true
     },
     "@types/node": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.0.1.tgz",
-      "integrity": "sha512-hBOx4SUlEPKwRi6PrXuTGw1z6lz0fjsibcWCM378YxsSu/6+C30L6CR49zIBKHiwNWCYIcOLjg4OHKZaFeLAug==",
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.3.1.tgz",
+      "integrity": "sha512-N87VuQi7HEeRJkhzovao/JviiqKjDKMVKxKMfUvSKw+MbkbW8R0nA3fi/MQhhlxV2fQ+2ReM+/Nt4efdrJx3zA==",
       "dev": true
     },
     "@types/yauzl": {
@@ -369,9 +380,9 @@
       "dev": true
     },
     "acorn-jsx": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
-      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true
     },
     "agent-base": {
@@ -475,12 +486,6 @@
       "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8=",
       "dev": true
     },
-    "array-ify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
-      "integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
-      "dev": true
-    },
     "array-includes": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.3.tgz",
@@ -515,6 +520,12 @@
         "define-properties": "^1.1.3",
         "es-abstract": "^1.18.0-next.1"
       }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
     },
     "astral-regex": {
       "version": "1.0.0",
@@ -625,12 +636,12 @@
       }
     },
     "bplist-parser": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.1.1.tgz",
-      "integrity": "sha1-1g1dzCDLptx+HymbNdPh+V2vuuY=",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.2.0.tgz",
+      "integrity": "sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==",
       "dev": true,
       "requires": {
-        "big-integer": "^1.6.7"
+        "big-integer": "^1.6.44"
       }
     },
     "brace-expansion": {
@@ -811,16 +822,6 @@
       "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
       "dev": true
     },
-    "compare-func": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.4.tgz",
-      "integrity": "sha512-sq2sWtrqKPkEXAC8tEJA1+BqAH9GbFkGBtUOqrUX57VSfwp8xyktctk+uLoRy5eccTdxzDcVIztlYDpKs3Jv1Q==",
-      "dev": true,
-      "requires": {
-        "array-ify": "^1.0.0",
-        "dot-prop": "^3.0.0"
-      }
-    },
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
@@ -884,41 +885,144 @@
       "dev": true
     },
     "cordova-android": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/cordova-android/-/cordova-android-8.1.0.tgz",
-      "integrity": "sha512-eAY6g9q3raJ4P03wNdSWC5MOW1EfxoomWNXsPhi7T6Q9yAqmxqn0sLEUjLL1Ib0LCH3nKQWBXdxapQ5LgbHu+g==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/cordova-android/-/cordova-android-9.1.0.tgz",
+      "integrity": "sha512-bzOX9E4eQsOSpa06oZZ7XAGq3DwB73juhhj0oPqHH/khWk0mkCD4aiVYMFoc0fmIaSQvzbY1ww7L6UBW5pyGfg==",
       "dev": true,
       "requires": {
-        "android-versions": "^1.4.0",
-        "compare-func": "^1.3.2",
-        "cordova-common": "^3.2.0",
-        "nopt": "^4.0.1",
+        "android-versions": "^1.5.0",
+        "cordova-common": "^4.0.1",
+        "execa": "^4.0.2",
+        "fast-glob": "^3.2.4",
+        "fs-extra": "^9.0.1",
+        "is-path-inside": "^3.0.2",
+        "nopt": "^4.0.3",
         "properties-parser": "^0.3.1",
-        "q": "^1.5.1",
-        "shelljs": "^0.5.3"
+        "semver": "^7.3.4",
+        "which": "^2.0.2"
+      },
+      "dependencies": {
+        "execa": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+          "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "human-signals": "^1.1.1",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.0",
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "human-signals": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+          "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
       }
     },
     "cordova-common": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/cordova-common/-/cordova-common-3.2.1.tgz",
-      "integrity": "sha512-xg0EnjnA6EipxXG8cupdlYQYeDA6+ghbN+Pjq88xN1LInwP6Bo7IyGBdSV5QnfjOvzShF9BBwSxBAv0FOO0C2Q==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/cordova-common/-/cordova-common-4.0.2.tgz",
+      "integrity": "sha512-od7aNShyuBajzPY83mUEO8tERwwWdFklXETHiXP5Ft87CWeo/tSuwNPFztyTy8XYc74yXdogXKPTJeUHuVzB8Q==",
       "dev": true,
       "requires": {
+        "@netflix/nerror": "^1.1.3",
         "ansi": "^0.3.1",
-        "bplist-parser": "^0.1.0",
-        "cross-spawn": "^6.0.5",
-        "elementtree": "0.1.7",
-        "endent": "^1.1.1",
-        "fs-extra": "^8.0.0",
-        "glob": "^7.1.2",
-        "minimatch": "^3.0.0",
+        "bplist-parser": "^0.2.0",
+        "cross-spawn": "^7.0.1",
+        "elementtree": "^0.1.7",
+        "endent": "^1.4.1",
+        "fast-glob": "^3.2.2",
+        "fs-extra": "^9.0.0",
+        "glob": "^7.1.6",
         "plist": "^3.0.1",
-        "q": "^1.4.1",
-        "strip-bom": "^3.0.0",
-        "underscore": "^1.8.3",
-        "which": "^1.3.0"
+        "q": "^1.5.1",
+        "read-chunk": "^3.2.0",
+        "strip-bom": "^4.0.0",
+        "underscore": "^1.9.2"
       },
       "dependencies": {
+        "strip-bom": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+          "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+          "dev": true
+        }
+      }
+    },
+    "cordova-ios": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/cordova-ios/-/cordova-ios-5.1.1.tgz",
+      "integrity": "sha512-asZMCj44JMe/PMrDIRC97GStPCH+GpaMNVe8hdmu8WWXJzMzRNRRJ339YYU89jitWf9ZKMdyBgrnSnQi5bJ/ZQ==",
+      "dev": true,
+      "requires": {
+        "cordova-common": "^3.1.0",
+        "ios-sim": "^8.0.1",
+        "nopt": "^4.0.1",
+        "plist": "^3.0.1",
+        "q": "^1.5.1",
+        "semver": "^6.3.0",
+        "shelljs": "^0.5.3",
+        "unorm": "^1.4.1",
+        "xcode": "^2.0.0",
+        "xml-escape": "^1.1.0"
+      },
+      "dependencies": {
+        "bplist-parser": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.1.1.tgz",
+          "integrity": "sha1-1g1dzCDLptx+HymbNdPh+V2vuuY=",
+          "dev": true,
+          "requires": {
+            "big-integer": "^1.6.7"
+          }
+        },
+        "cordova-common": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/cordova-common/-/cordova-common-3.2.1.tgz",
+          "integrity": "sha512-xg0EnjnA6EipxXG8cupdlYQYeDA6+ghbN+Pjq88xN1LInwP6Bo7IyGBdSV5QnfjOvzShF9BBwSxBAv0FOO0C2Q==",
+          "dev": true,
+          "requires": {
+            "ansi": "^0.3.1",
+            "bplist-parser": "^0.1.0",
+            "cross-spawn": "^6.0.5",
+            "elementtree": "0.1.7",
+            "endent": "^1.1.1",
+            "fs-extra": "^8.0.0",
+            "glob": "^7.1.2",
+            "minimatch": "^3.0.0",
+            "plist": "^3.0.1",
+            "q": "^1.4.1",
+            "strip-bom": "^3.0.0",
+            "underscore": "^1.8.3",
+            "which": "^1.3.0"
+          }
+        },
         "cross-spawn": {
           "version": "6.0.5",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -930,6 +1034,14 @@
             "semver": "^5.5.0",
             "shebang-command": "^1.2.0",
             "which": "^1.2.9"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.7.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+              "dev": true
+            }
           }
         },
         "fs-extra": {
@@ -956,12 +1068,6 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
           "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-          "dev": true
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         },
         "shebang-command": {
@@ -994,24 +1100,6 @@
             "isexe": "^2.0.0"
           }
         }
-      }
-    },
-    "cordova-ios": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/cordova-ios/-/cordova-ios-5.1.1.tgz",
-      "integrity": "sha512-asZMCj44JMe/PMrDIRC97GStPCH+GpaMNVe8hdmu8WWXJzMzRNRRJ339YYU89jitWf9ZKMdyBgrnSnQi5bJ/ZQ==",
-      "dev": true,
-      "requires": {
-        "cordova-common": "^3.1.0",
-        "ios-sim": "^8.0.1",
-        "nopt": "^4.0.1",
-        "plist": "^3.0.1",
-        "q": "^1.5.1",
-        "semver": "^6.3.0",
-        "shelljs": "^0.5.3",
-        "unorm": "^1.4.1",
-        "xcode": "^2.0.0",
-        "xml-escape": "^1.1.0"
       }
     },
     "cors": {
@@ -1135,15 +1223,6 @@
         "void-elements": "^2.0.0"
       }
     },
-    "dot-prop": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
-      "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
-      "dev": true,
-      "requires": {
-        "is-obj": "^1.0.0"
-      }
-    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -1151,9 +1230,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.770",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.770.tgz",
-      "integrity": "sha512-Kyh8DGK1KfEZuYKIHvuOmrKotsKZQ+qBkDIWHciE3QoFkxXB1KzPP+tfLilSHAfxTON0yYMnFCWkQtUOR7g6KQ==",
+      "version": "1.3.772",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.772.tgz",
+      "integrity": "sha512-X/6VRCXWALzdX+RjCtBU6cyg8WZgoxm9YA02COmDOiNJEZ59WkQggDbWZ4t/giHi/3GS+cvdrP6gbLISANAGYA==",
       "dev": true
     },
     "elementtree": {
@@ -1737,6 +1816,12 @@
         }
       }
     },
+    "extsprintf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.0.tgz",
+      "integrity": "sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=",
+      "dev": true
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1744,9 +1829,9 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.6.tgz",
-      "integrity": "sha512-GnLuqj/pvQ7pX8/L4J84nijv6sAnlwvSDpMkJi9i7nPmPxGtRPkBSStfvDW5l6nMdX9VWe+pkKWFTgD+vF2QSQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
+      "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -2659,10 +2744,10 @@
       "integrity": "sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw==",
       "dev": true
     },
-    "is-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+    "is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
       "dev": true
     },
     "is-plain-object": {
@@ -3063,6 +3148,15 @@
         "streamroller": "^2.2.4"
       }
     },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -3387,6 +3481,12 @@
         "os-homedir": "^1.0.0",
         "os-tmpdir": "^1.0.0"
       }
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
     },
     "p-limit": {
       "version": "1.3.0",
@@ -3731,6 +3831,24 @@
         "unpipe": "1.0.0"
       }
     },
+    "read-chunk": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-3.2.0.tgz",
+      "integrity": "sha512-CEjy9LCzhmD7nUpJ1oVOE6s/hBkejlcJEgLQHVnQznOSilOPb+kpKktlLfFDK3/WP43+F80xkUTM2VOkYoSYvQ==",
+      "dev": true,
+      "requires": {
+        "pify": "^4.0.1",
+        "with-open-file": "^0.1.6"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
+        }
+      }
+    },
     "read-pkg": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
@@ -3970,17 +4088,6 @@
         "bplist-creator": "0.0.8",
         "bplist-parser": "0.2.0",
         "plist": "^3.0.1"
-      },
-      "dependencies": {
-        "bplist-parser": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.2.0.tgz",
-          "integrity": "sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==",
-          "dev": true,
-          "requires": {
-            "big-integer": "^1.6.44"
-          }
-        }
       }
     },
     "slash": {
@@ -4553,6 +4660,31 @@
         "is-symbol": "^1.0.3"
       }
     },
+    "with-open-file": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/with-open-file/-/with-open-file-0.1.7.tgz",
+      "integrity": "sha512-ecJS2/oHtESJ1t3ZfMI3B7KIDKyfN0O16miWxdn30zdh66Yd3LsRFebXZXq6GU4xfxLf6nVxp9kIqElb5fqczA==",
+      "dev": true,
+      "requires": {
+        "p-finally": "^1.0.0",
+        "p-try": "^2.1.0",
+        "pify": "^4.0.1"
+      },
+      "dependencies": {
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
+        }
+      }
+    },
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -4658,6 +4790,12 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
     "yargs": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@cordova/eslint-config": "^3.0.0",
-    "cordova-android": "^8.1.0",
+    "cordova-android": "^9.1.0",
     "cordova-ios": "^5.1.1",
     "eslint-plugin-es5": "^1.5.0",
     "grunt": "^1.4.1",


### PR DESCRIPTION
### Motivation, Context & Description

This PR:
* Removes a high severity vulnerability found in `cordova-android`, one of the `devDependency` of this package for testing.
* Rebuilt `package-lock.json`

### Testing

- `npm t`


### Checklist

- [x] I've run the tests to see all new and existing tests pass
