### PR TITLE
perf(fromArrayBuffer): use less memory for large buffers

### DIFF
--- a/src/common/base64.js
+++ b/src/common/base64.js
@@ -23,7 +23,7 @@ var base64 = exports;
 
 base64.fromArrayBuffer = function (arrayBuffer) {
     var array = new Uint8Array(arrayBuffer);
-    return uint8ToBase64(array);
+    return btoa(bytesToBinaryString(array));
 };
 
 base64.toArrayBuffer = function (str) {
@@ -36,46 +36,12 @@ base64.toArrayBuffer = function (str) {
     return arrayBuffer;
 };
 
-// ------------------------------------------------------------------------------
-
-/* This code is based on the performance tests at http://jsperf.com/b64tests
- * This 12-bit-at-a-time algorithm was the best performing version on all
- * platforms tested.
- */
-
-var b64_6bit = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
-var b64_12bit;
-
-var b64_12bitTable = function () {
-    b64_12bit = [];
-    for (var i = 0; i < 64; i++) {
-        for (var j = 0; j < 64; j++) {
-            b64_12bit[i * 64 + j] = b64_6bit[i] + b64_6bit[j];
-        }
+function bytesToBinaryString (bytes) {
+    var CHUNK_SIZE = 1 << 15;
+    var string = '';
+    for (var i = 0; i < bytes.length; i += CHUNK_SIZE) {
+        var chunk = bytes.subarray(i, i + CHUNK_SIZE);
+        string += String.fromCharCode.apply(null, chunk);
     }
-    b64_12bitTable = function () { return b64_12bit; };
-    return b64_12bit;
-};
-
-function uint8ToBase64 (rawData) {
-    var numBytes = rawData.byteLength;
-    var output = '';
-    var segment;
-    var table = b64_12bitTable();
-    for (var i = 0; i < numBytes - 2; i += 3) {
-        segment = (rawData[i] << 16) + (rawData[i + 1] << 8) + rawData[i + 2];
-        output += table[segment >> 12];
-        output += table[segment & 0xfff];
-    }
-    if (numBytes - i === 2) {
-        segment = (rawData[i] << 16) + (rawData[i + 1] << 8);
-        output += table[segment >> 12];
-        output += b64_6bit[(segment & 0xfff) >> 6];
-        output += '=';
-    } else if (numBytes - i === 1) {
-        segment = (rawData[i] << 16);
-        output += table[segment >> 12];
-        output += '==';
-    }
-    return output;
+    return string;
 }

--- a/test/test.base64.js
+++ b/test/test.base64.js
@@ -53,6 +53,14 @@ describe('base64', function () {
         );
     });
 
+    it('can base64 encode big files reasonably fast', function () {
+        var bytes = Uint8Array.from({ length: 1 << 24 }, (v, i) => i & 0xff);
+
+        var start = Date.now();
+        base64.fromArrayBuffer(bytes.buffer);
+        expect(Date.now() - start).toBeLessThan(1000);
+    });
+
     it('Test#003 : can base64 encode an text string in an ArrayBuffer', function () {
         var orig = 'Some Awesome Test This Is!';
         var base64string = btoa(orig);


### PR DESCRIPTION
### Platforms affected
All


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This improves performance for converting large files to Base64 strings (see apache/cordova-plugin-file#364 for more info, especially the extensive performance analysis by @LightMind).

Another win here, is that we reduce the code size considerably. A downside is that we actually loose a bit of performance for small instances, but I do not think that this would be noticeable.

I explored different approaches here, like converting the original algorithm to use ArrayBuffers. The problem here is that we still need to convert the end result to a string which then becomes a performance bottleneck if you do not have support for `TextDecoder` (which we cannot assume with our current ES5 target).

Fixes #241


### Description
<!-- Describe your changes in detail -->
`base64.fromArrayBuffer` now uses `btoa` to convert bytes to a base64 encoded string. We already use its counterpart `atob` in `base64.toArrayBuffer`. Since `btoa` unfortunately operates on binary strings instead of buffers, we first need to convert the raw bytes to a [binary string](https://developer.mozilla.org/en-US/docs/Web/API/DOMString/Binary). This is the main performance bottleneck here, but applying `String.fromCharCode` to large chunks of data works reasonably well.

### Testing
<!-- Please describe in detail how you tested your changes. -->
I added a test that should hopefully preventing people from making stupid changes in the future. However, its reliance on an absolute expected runtime might lead to problems in the future.

I also did some performance comparisons (ops/s) between the new and old version in my local Chrome browser:

|bytes |   old |   new | new/old|
|------|-------|-------|--------|
| 1K | 61409 | 33029 |     54%|
| 32K |  1569 |   913 |     58%|
| 1M |    11 |    24 |    218%|
| 32M |    .3 |    .9 |    300%|

