### PR TITLE
chore(ci): Add Node 22 to CI and fix dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,10 +47,22 @@ jobs:
           node --version
           npm --version
 
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: javascript
+          queries: security-and-quality
+          config: |
+            paths-ignore:
+              - pkg
+              - coverage
+              - node_modules
+
       - name: npm install and test
         run: npm cit
         env:
           CI: true
+
+      - uses: github/codeql-action/analyze@v3
 
       - uses: codecov/codecov-action@v4
         if: success()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,13 @@
 
 name: Node CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/*'
+  pull_request:
+    branches:
+      - '*'
 
 jobs:
   test:
@@ -25,7 +31,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [16.x, 18.x, 20.x, 22.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:


### PR DESCRIPTION
### Description
<!-- Describe your changes in detail -->
* Add Node 22 to CI
* Don't run `push` events on Dependabot PRs because it can break things
* Add CodeQL scanning