### PR TITLE
fix(glob): fs.glob uses native path separator which broke module IDs

### DIFF
--- a/build-tools/common.js
+++ b/build-tools/common.js
@@ -64,7 +64,8 @@ module.exports = {
         return glob(['**/*.js'], { cwd: dir })
             .map(fileName => ({
                 path: path.join(dir, fileName),
-                moduleId: fileName.slice(0, -3)
+                // This is used as an identifier with URL-style (POSIX-style) path separators
+                moduleId: fileName.replaceAll(path.sep, path.posix.sep).slice(0, -3)
             }))
             .map(file => ({ [file.moduleId]: file }))
             .reduce((result, fragment) => Object.assign(result, fragment), {});


### PR DESCRIPTION
Should have added Node 22 to CI _before_ doing the `fs.globSync` change 🤦🏼‍♂️ 

### Platforms affected
Windows


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
So `fs.glob` returns paths using the system path separator, while `fast-glob` and `globby` always return POSIX-style paths. Since we use this value for module IDs (i.e., `cordova.require('some/module/path')`) we need to ensure the IDs use POSIX-style separators.

NodeJS apparently still doesn't have an API to fix this beyond just doing string replacements.


### Description
<!-- Describe your changes in detail -->
Force module IDs to always use POSIX-style path separators.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Ran tests in CI with logging to reproduce and fix the bug.


### Checklist

- [x] I've run the tests to see all new and existing tests pass