### PR TITLE
fix: Fix potential edge case in cordova.js detection

### DIFF
--- a/src/common/pluginloader.js
+++ b/src/common/pluginloader.js
@@ -101,7 +101,8 @@ function findCordovaPath () {
     var term = '/cordova.js';
     for (var n = scripts.length - 1; n > -1; n--) {
         var src = scripts[n].src.replace(/\?.*$/, ''); // Strip any query param (CB-6007).
-        if (src.indexOf(term) === (src.length - term.length)) {
+        var index = src.indexOf(term);
+        if (index !== -1 && index === (src.length - term.length)) {
             path = src.substring(0, src.length - term.length) + '/';
             break;
         }


### PR DESCRIPTION
Because `indexOf` returns -1 in the case of no match, and a subtraction of string lengths can also potentially result in -1, we want to make sure the index is **not** -1 before we try to substring with it.